### PR TITLE
WIP: Add basic docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
-install: ./gradlew install
-script: ./gradlew build -i
+
+services:
+  - docker
+
+script:
+  - ./gradlew build
+  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+  - docker build ./ -t donniewest/kotlinlanguageserver:latest
+  - docker push donniewest/kotlinlanguageserver:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Running this container will start a language server that listens for TCP connections on port 2088
+# Every connection will be run in a forked child process
+
+# Please note that before building the image, you have to build the language server with `./gradlew build`
+
+FROM openjdk:10
+
+COPY ./build/install ./
+
+EXPOSE 2088
+
+CMD ["./kotlin-language-server/bin/kotlin-language-server", "--tcp-server=0:2088"]


### PR DESCRIPTION
Fixes #13 

Todo:

- [X] Build and deploy docker image
- [ ] Switch to @fwcd Dockerhub account
- [ ] Figure out if we _can_ communicate over stdio/stdin on Docker
- [ ] If we can't use stdin/stdio, allow communication over a specified port

It seems that LSP docker images in the wild are using a port to communicate, so that might very well be the way we need to go if we want a docker image for this. Image is currently set up to pretend there's a flag for it even though that doesn't currently exist