### PR TITLE
Use separate compilation environments for files and expressions

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -60,7 +60,7 @@ class SourcePath(private val cp: CompilerClassPath) {
         private fun doPrepareCompiledFile(): CompiledFile =
                 CompiledFile(content, compiledFile!!, compiledContext!!, compiledContainer!!, all(), cp)
     }
-    
+
     private fun sourceFile(file: Path): SourceFile {
         if (file !in files) {
             LOG.warn("File {} is not on SourcePath, adding it now...", file)

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
@@ -9,7 +9,7 @@ import org.javacs.kt.Compiler
 import org.javacs.kt.util.nonNull
 
 fun convertJavaToKotlin(javaCode: String, compiler: Compiler): String {
-    val psiFactory = PsiFileFactory.getInstance(compiler.environment.project)
+    val psiFactory = compiler.psiFileFactory
     val javaAST = psiFactory.createFileFromText("snippet.java", JavaLanguage.INSTANCE, javaCode)
     LOG.info("Parsed {} to {}", javaCode, javaAST)
 


### PR DESCRIPTION
To make sure that project services such as the ModuleAnnotationResolver
do no throw concurrency exceptions if an expression happens to be
compiled at the same time as a file.

These issues did occur frequently before, see #42.