### PR TITLE
Use Field icon instead of Property icon for class properties in autocomplete. 

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt
@@ -49,7 +49,7 @@ class RenderCompletionItem(val snippetsEnabled: Boolean) : DeclarationDescriptor
     override fun visitPropertySetterDescriptor(desc: PropertySetterDescriptor, nothing: Unit?): CompletionItem {
         setDefaults(desc)
 
-        result.kind = Property
+        result.kind = Field
 
         return result
     }
@@ -173,7 +173,7 @@ class RenderCompletionItem(val snippetsEnabled: Boolean) : DeclarationDescriptor
     override fun visitPropertyGetterDescriptor(desc: PropertyGetterDescriptor, nothing: Unit?): CompletionItem {
         setDefaults(desc)
 
-        result.kind = Property
+        result.kind = Field
 
         return result
     }
@@ -189,7 +189,7 @@ class RenderCompletionItem(val snippetsEnabled: Boolean) : DeclarationDescriptor
     override fun visitPropertyDescriptor(desc: PropertyDescriptor, nothing: Unit?): CompletionItem {
         setDefaults(desc)
 
-        result.kind = Property
+        result.kind = Field
 
         return result
     }


### PR DESCRIPTION
This follows the convention used by other language servers in VS Code which have synthetic (get/set) properties, like JS, Typescript, and C#. The weird bit here, is that Kotlin compiler identifies all val/vars on a class, even those that are not synthetic, as Properties. Presumably to autogenerate get/set methods on the Java side.

Field icon is a blue box, which is typical for class fields AND class properties. Property is grey nondescript wrench, and it's unclear that it even is or what it does.

I'm unsure what the Property type is used for, but for consistency with how other language servers display fields and synthetic properties within VSCode, the Field enum/icon is the correct behavior.