### PR TITLE
Fixes for startScript task.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,6 +19,12 @@ def debugArgs = '-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspen
 
 startScripts {
     applicationName = "kotlin-language-server"
+    doLast {
+        def windowsScriptFile = file getWindowsScript()
+        def unixScriptFile    = file getUnixScript()
+        windowsScriptFile.text = windowsScriptFile.text.replace('%APP_HOME%\\lib', '%APP_HOME%\\install\\server\\lib')
+        unixScriptFile.text  = unixScriptFile.text.replace('$APP_HOME/lib', '$APP_HOME/install/server/lib')
+    }
 }
 
 repositories {


### PR DESCRIPTION
This change fixes the generated `CLASSPATH` that has previously caused the generated bash script to fail with a ClassNotFound exception. This should resolve issues for coc.nvim users, which uses this script to run the language server.
I have tested this on my MacOS 10.15 machine. 