### PR TITLE
Using DocumentSymbol instead of SymbolInformation for documentSymbols so that a structure can be provided.

### DIFF
--- a/server/src/test/kotlin/org/javacs/kt/DocumentSymbolsTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/DocumentSymbolsTest.kt
@@ -1,11 +1,14 @@
 package org.javacs.kt
 
+import org.eclipse.lsp4j.DocumentSymbol
 import org.eclipse.lsp4j.DocumentSymbolParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.SymbolKind
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.not
-import org.junit.Assert.assertThat
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -19,14 +22,14 @@ class DocumentSymbolsTest : LanguageServerTestFixture("symbols") {
     @Test fun `find document symbols`() {
         val fileId = TextDocumentIdentifier(uri(file).toString())
         val found = languageServer.textDocumentService.documentSymbol(DocumentSymbolParams(fileId)).get()
-        val byKind = found.groupBy({ it.left.kind }, { it.left.name })
-        val all = found.map { it.left.name }.toList()
+        val expected = listOf(DocumentSymbol("DocumentSymbols", SymbolKind.Class, Range(Position(0, 0), Position(8, 1)), Range(Position(0, 14), Position(0, 29)), null, listOf(
+            DocumentSymbol("DocumentSymbols", SymbolKind.Constructor, Range(Position(0, 29), Position(0, 31)), Range(Position(0, 29), Position(0, 31)), null, listOf()),
+            DocumentSymbol("aProperty", SymbolKind.Property, Range(Position(1, 4), Position(1, 21)), Range(Position(1, 8), Position(1, 17)), null, listOf()),
+            DocumentSymbol("aFunction", SymbolKind.Function, Range(Position(3, 4), Position(4, 5)), Range(Position(3, 8), Position(3, 17)), null, listOf()),
+            DocumentSymbol("DocumentSymbols", SymbolKind.Constructor, Range(Position(6, 4), Position(7, 5)), Range(Position(6, 4), Position(7, 5)), null, listOf())
+        )))
+        val all = found.map { it.right }.toList()
 
-        assertThat(byKind[SymbolKind.Class], hasItem("DocumentSymbols"))
-        assertThat(byKind[SymbolKind.Constructor], hasItem("DocumentSymbols"))
-        assertThat(byKind[SymbolKind.Property], hasItem("aProperty"))
-        assertThat(byKind[SymbolKind.Function], hasItem("aFunction"))
-        assertThat(all, not(hasItem("aFunctionArg")))
-        assertThat(all, not(hasItem("aConstructorArg")))
+        assertEquals(all.toString(), expected, all)
     }
 }


### PR DESCRIPTION
As said in the title - returning DocumentSymbol(s) from textDocument/documentSymbol instead of SymbolInformation allows to show the structure of the document. So it would be very nice if DocumentSymbol(s) could be returned. As possible patch is herein.