### PR TITLE
Improving linting/diagnostic reporting - ability to cancel the progr…

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -303,9 +303,8 @@ class KotlinTextDocumentService(
         shutdownExecutors(awaitTermination = true)
     }
 
-    fun setTestLintRecompilationCallback(callback: () -> Unit) {
-        sp.beforeCompileCallback = callback;
-    }
+    var lintRecompilationCallback: () -> Unit = {}
+        set(callback) { sp.beforeCompileCallback = callback }
 }
 
 private inline fun<T> reportTime(block: () -> T): T {

--- a/server/src/test/kotlin/org/javacs/kt/DebouncerTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/DebouncerTest.kt
@@ -12,7 +12,7 @@ class DebouncerTest {
 
     @Test fun callQuickly() {
         for (i in 1..10) {
-            debounce.submit {
+            debounce.submit { ->
                 counter++
             }
         }

--- a/server/src/test/kotlin/org/javacs/kt/LintTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LintTest.kt
@@ -34,13 +34,13 @@ class LintTest : SingleFileTestFixture("lint", "LintErrors.kt") {
     @Test fun `linting should not be dropped if another linting is running`() {
         var callbackCount = 0;
         languageServer.textDocumentService.debounceLint.waitForPendingTask()
-        languageServer.textDocumentService.setTestLintRecompilationCallback({
+        languageServer.textDocumentService.lintRecompilationCallback = {
             if (callbackCount++ == 0) {
                 diagnostics.clear()
                 replace(file, 3, 9, "return 11", "")
                 languageServer.textDocumentService.documentSymbol(DocumentSymbolParams(TextDocumentIdentifier(uri(file).toString()))).get()
             }
-        })
+        }
         replace(file, 3, 16, "", "1")
 
         while (callbackCount < 2) {
@@ -51,6 +51,6 @@ class LintTest : SingleFileTestFixture("lint", "LintErrors.kt") {
 
         languageServer.textDocumentService.debounceLint.waitForPendingTask()
         assertThat(diagnostics, empty<Diagnostic>())
-        languageServer.textDocumentService.setTestLintRecompilationCallback({})
+        languageServer.textDocumentService.lintRecompilationCallback = {}
     }
 }

--- a/server/src/test/kotlin/org/javacs/kt/LintTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LintTest.kt
@@ -31,7 +31,7 @@ class LintTest : SingleFileTestFixture("lint", "LintErrors.kt") {
         assertThat(languageServer.textDocumentService.lintCount, lessThan(5))
     }
 
-    @Test fun `lintting should not be dropped if another lintting is running`() {
+    @Test fun `linting should not be dropped if another linting is running`() {
         var callbackCount = 0;
         languageServer.textDocumentService.debounceLint.waitForPendingTask()
         languageServer.textDocumentService.setTestLintRecompilationCallback({


### PR DESCRIPTION
…ess, ensure stale data are not recorded SourceFile(s), always start linting on change.

I was using the server inside NetBeans (to edit the server's sources themselves), and among other things noted the diagnostics/lint behavior is not ideal - sometimes, after typing a bit, then pausing and typing more, the diagnostics shown are for the state where I paused, not for the final state (regardless how long I wait). So I tried to fix this - I'll add some comments on particular changes to explain why I did them.