### PR TITLE
Fix TeamCity dependencies plugin requires Gradle 5.3. Gradle 6.1-rc-2…

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'maven'
     id 'application'
-	id 'com.github.jk1.tcdeps' version '0.19'
+	id 'com.github.jk1.tcdeps' version '1.2'
     id 'com.jaredsburrows.license' version '0.8.42'
 }
 


### PR DESCRIPTION
… detected. #183