### PR TITLE
Include kotlin-stdlib-common

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/WithStdlibResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/WithStdlibResolver.kt
@@ -13,7 +13,10 @@ internal class WithStdlibResolver(private val wrapped: ClassPathResolver) : Clas
 
 private fun wrapWithStdlib(paths: Set<Path>): Set<Path> {
     // Ensure that there is exactly one kotlin-stdlib present, and/or exactly one of kotlin-stdlib-common, -jdk8, etc.
-    val isStdlib: ((Path) -> Boolean) = { it.toString().contains("kotlin-stdlib") }
+    val isStdlib: ((Path) -> Boolean) = {
+        val pathString = it.toString()
+        pathString.contains("kotlin-stdlib") && !pathString.contains("kotlin-stdlib-common")
+    }
 
     val linkedStdLibs = paths.filter(isStdlib)
         .mapNotNull { StdLibItem.from(it) }


### PR DESCRIPTION
By excluding kotlin-stdlib-common as a stdlib replacement, we ensure that a valid stdlib is available in the case that the kotlin-stdlib is removed and kotlin-stdlib-common remains. Since the common library isn't a full stdlib, sometimes projects will error in their completion

Resolves #187 