### PR TITLE
fix error where mvn hangs if anything is output to stderr

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "java.configuration.updateBuildConfiguration": "automatic"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/shared/src/main/kotlin/org/javacs/kt/util/Utils.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/util/Utils.kt
@@ -17,8 +17,14 @@ fun execAndReadStdoutAndStderr(shellCommand: String, directory: Path): Pair<Stri
     val process = Runtime.getRuntime().exec(shellCommand, null, directory.toFile())
     val stdout = process.inputStream
     val stderr = process.errorStream
-    val output = stdout.bufferedReader().use { it.readText() }
-    val errors = stderr.bufferedReader().use { it.readText() }
+    var output = ""
+    var errors = ""
+    val outputThread = Thread { stdout.bufferedReader().use { output += it.readText() } }
+    val errorsThread = Thread { stderr.bufferedReader().use { errors += it.readText() } }
+    outputThread.start()
+    errorsThread.start()
+    outputThread.join()
+    errorsThread.join()
     return Pair(output, errors)
 }
 


### PR DESCRIPTION
Hey there! We were seeing the same thing as #180 when our server started up. We figured out that `mvn dependency:list` writes to `stderr` in our case due to some weirdness, and that was causing the call to `Runtime.getRuntime().exec()` to hang forever, since it was blocking until `stderr` was read. This just passes `stderr` along as if it were stdout, which makes the language server work perfectly for us.