### PR TITLE
Fix whitespace in path crashes the server

### DIFF
--- a/server/src/test/kotlin/org/javacs/kt/OneFilePerformance.kt
+++ b/server/src/test/kotlin/org/javacs/kt/OneFilePerformance.kt
@@ -1,22 +1,17 @@
 package org.javacs.kt
 
-import org.jetbrains.kotlin.com.intellij.openapi.Disposable
-import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.StandardFileSystems
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFile
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileManager
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileSystem
-import org.jetbrains.kotlin.com.intellij.psi.PsiManager
-import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+import org.javacs.kt.util.LoggingMessageCollector
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.jvm.compiler.CliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.openapi.vfs.StandardFileSystems
+import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileManager
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.container.ComponentProvider
-import org.jetbrains.kotlin.container.ValueDescriptor
-import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
@@ -25,23 +20,15 @@ import org.jetbrains.kotlin.resolve.BindingTraceContext
 import org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer
 import org.jetbrains.kotlin.resolve.TopDownAnalysisMode
 import org.jetbrains.kotlin.resolve.calls.callUtil.getParentResolvedCall
-import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowInfoFactory
 import org.junit.Test
-import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.annotations.Scope
-import org.openjdk.jmh.annotations.State
-import org.openjdk.jmh.annotations.TearDown
-import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.runner.Runner
 import org.openjdk.jmh.runner.RunnerException
-import org.openjdk.jmh.runner.options.Options
 import org.openjdk.jmh.runner.options.OptionsBuilder
-import org.javacs.kt.util.LoggingMessageCollector
-
-import java.lang.reflect.Type
-import java.net.URL
 import java.io.Closeable
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 class OneFilePerformance {
     @State(Scope.Thread)
@@ -61,7 +48,7 @@ class OneFilePerformance {
 
         internal fun openFile(resourcePath: String?): KtFile {
             val locate = OneFilePerformance::class.java.getResource(resourcePath)
-            val file = fileSystem.findFileByPath(locate.path)
+            val file = fileSystem.findFileByPath(URLDecoder.decode(locate.path, StandardCharsets.UTF_8.toString()))
             return PsiManager.getInstance(env.project).findFile(file!!) as KtFile
         }
 

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -15,6 +15,7 @@ repositories {
 
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib'
+    implementation 'org.eclipse.core.runtime:compatibility:3.1.200-v20070502'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 	testImplementation 'junit:junit:4.11'
 }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -15,7 +15,6 @@ repositories {
 
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib'
-    implementation 'org.eclipse.core.runtime:compatibility:3.1.200-v20070502'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 	testImplementation 'junit:junit:4.11'
 }

--- a/shared/src/main/kotlin/org/javacs/kt/util/URIs.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/util/URIs.kt
@@ -1,8 +1,9 @@
 package org.javacs.kt.util
 
-import java.nio.charset.StandardCharsets
+import org.eclipse.core.runtime.URIUtil
 import java.net.URI
 import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -11,7 +12,8 @@ import java.nio.file.Paths
  * Decoding is necessary since some language clients
  * (including VSCode) invalidly percent-encode colons.
  */
-fun parseURI(uri: String): URI = URI.create(runCatching { URLDecoder.decode(uri, StandardCharsets.UTF_8.toString()) }.getOrDefault(uri))
+fun parseURI(uri: String): URI =
+    URIUtil.fromString(runCatching { URLDecoder.decode(uri, StandardCharsets.UTF_8.toString()) }.getOrDefault(uri))
 
 val URI.filePath: Path? get() = runCatching { Paths.get(this) }.getOrNull()
 

--- a/shared/src/main/kotlin/org/javacs/kt/util/URIs.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/util/URIs.kt
@@ -1,6 +1,5 @@
 package org.javacs.kt.util
 
-import org.eclipse.core.runtime.URIUtil
 import java.net.URI
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
@@ -13,7 +12,7 @@ import java.nio.file.Paths
  * (including VSCode) invalidly percent-encode colons.
  */
 fun parseURI(uri: String): URI =
-    URIUtil.fromString(runCatching { URLDecoder.decode(uri, StandardCharsets.UTF_8.toString()) }.getOrDefault(uri))
+    URI.create(runCatching { URLDecoder.decode(uri.replace(" ", "%20"), StandardCharsets.UTF_8.toString()) }.getOrDefault(uri))
 
 val URI.filePath: Path? get() = runCatching { Paths.get(this) }.getOrNull()
 

--- a/shared/src/test/kotlin/org/javacs/kt/URIsTest.kt
+++ b/shared/src/test/kotlin/org/javacs/kt/URIsTest.kt
@@ -1,0 +1,31 @@
+package org.javacs.kt
+
+import org.junit.Assert.assertEquals
+import org.javacs.kt.util.parseURI
+import org.junit.Test
+import java.net.URI
+
+class URIsTest {
+    @Test
+    fun `parseURI should work with different paths`() {
+        assertEquals(
+            URI.create("/home/ws%201"),
+            parseURI("/home/ws 1")
+        )
+
+        assertEquals(
+            URI.create("/home/ws-1"),
+            parseURI("/home/ws-1")
+        )
+
+        assertEquals(
+            URI.create("file:/home/ws%201"),
+            parseURI("file:///home/ws%201")
+        )
+
+        assertEquals(
+            URI.create("file:/home/ws%201"),
+            parseURI("file%3A%2F%2F%2Fhome%2Fws%201")
+        )
+    }
+}


### PR DESCRIPTION
To fix #200,

This PR fixes the whitespace issue that results crashing the server at initialization phase.