### PR TITLE
Update tests for Kotlin 1.4's new type inference

### DIFF
--- a/server/src/test/kotlin/org/javacs/kt/ClassPathTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/ClassPathTest.kt
@@ -21,9 +21,9 @@ class ClassPathTest {
 
         assertTrue(Files.exists(buildFile))
 
-        val classPath = defaultClassPathResolver(listOf(workspaceRoot)).classpathOrEmpty
+        val classPath = defaultClassPathResolver(listOf(workspaceRoot)).classpathOrEmpty.map { it.toString() }
 
-        assertThat(classPath, hasItem(hasToString(containsString("junit"))))
+        assertThat(classPath, hasItem(containsString("junit")))
     }
 
     @Test fun `find kotlin stdlib`() {

--- a/server/src/test/kotlin/org/javacs/kt/DefinitionTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/DefinitionTest.kt
@@ -15,17 +15,19 @@ class DefinitionTest : SingleFileTestFixture("definition", "GoFrom.kt") {
     @Test
     fun `go to a definition in the same file`() {
         val definitions = languageServer.textDocumentService.definition(textDocumentPosition(file, 3, 24)).get().left
+        val uris = definitions.map { it.uri }
 
         assertThat(definitions, hasSize(1))
-        assertThat(definitions, hasItem(hasProperty("uri", containsString("GoFrom.kt"))))
+        assertThat(uris, hasItem(containsString("GoFrom.kt")))
     }
 
     @Test
     fun `go to a definition in a different file`() {
         val definitions = languageServer.textDocumentService.definition(textDocumentPosition(file, 4, 24)).get().left
+        val uris = definitions.map { it.uri }
 
         assertThat(definitions, hasSize(1))
-        assertThat(definitions, hasItem(hasProperty("uri", containsString("GoTo.kt"))))
+        assertThat(uris, hasItem(containsString("GoTo.kt")))
     }
 }
 
@@ -65,11 +67,12 @@ class GoToDefinitionOfPropertiesTest : SingleFileTestFixture("definition", "GoTo
     }
 
     private fun assertGoToProperty(of: Position, expect: Range) {
-        val definitions = languageServer.textDocumentService
-            .definition(textDocumentPosition(file, of)).get().left
+        val definitions = languageServer.textDocumentService.definition(textDocumentPosition(file, of)).get().left
+        val uris = definitions.map { it.uri }
+        val ranges = definitions.map { it.range }
 
         assertThat(definitions, hasSize(1))
-        assertThat(definitions, hasItem(hasProperty("uri", containsString(file))))
-        assertThat(definitions, hasItem(hasProperty("range", equalTo(expect))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat(ranges, hasItem(equalTo(expect)))
     }
 }

--- a/server/src/test/kotlin/org/javacs/kt/ReferencesTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/ReferencesTest.kt
@@ -9,8 +9,8 @@ class ReferencesTest : SingleFileTestFixture("references", "ReferenceTo.kt") {
         val request = referenceParams(file, 2, 11)
         val references = languageServer.textDocumentService.references(request).get()
 
-        assertThat("Finds references within a file", references, hasItem(hasProperty("uri", containsString("ReferenceTo.kt"))))
-        assertThat("Finds references across files", references, hasItem(hasProperty("uri", containsString("ReferenceFrom.kt"))))
+        assertThat("Finds references within a file", references, hasItem(containsString("ReferenceTo.kt")))
+        assertThat("Finds references across files", references, hasItem(containsString("ReferenceFrom.kt")))
     }
 }
 
@@ -18,26 +18,31 @@ class ReferenceCollectionishTest : SingleFileTestFixture("references", "Referenc
     @Test fun `find references to iterator`() {
         val request = referenceParams(file, 2, 21)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
-        assertThat("Finds for-loop reference", references, hasItem(hasToString(containsString("line = 8"))))
-        assertThat("Finds iterator() reference", references, hasItem(hasToString(containsString("line = 9"))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat("Finds for-loop reference", referenceStrs, hasItem(containsString("line = 8")))
+        assertThat("Finds iterator() reference", referenceStrs, hasItem(containsString("line = 9")))
     }
 
     @Test fun `find references to contains`() {
         val request = referenceParams(file, 3, 21)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
-        assertThat("Finds reference using in", references, hasItem(hasToString(containsString("line = 10"))))
-        assertThat("Finds contains() reference", references, hasItem(hasToString(containsString("line = 11"))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat("Finds reference using in", referenceStrs, hasItem(containsString("line = 10")))
+        assertThat("Finds contains() reference", referenceStrs, hasItem(containsString("line = 11")))
     }
 
     @Test fun `find references to rangeTo`() {
         val request = referenceParams(file, 4, 21)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 }
 
@@ -45,10 +50,12 @@ class ReferenceComponentsTest : SingleFileTestFixture("references", "ReferenceCo
     @Test fun `find references to component1`() {
         val request = referenceParams(file, 2, 21)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
-        assertThat("Finds destructuring reference", references, hasItem(hasToString(containsString("line = 6"))))
-        assertThat("Finds component1() reference", references, hasItem(hasToString(containsString("line = 7"))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat("Finds destructuring reference", referenceStrs, hasItem(containsString("line = 6")))
+        assertThat("Finds component1() reference", referenceStrs, hasItem(containsString("line = 7")))
     }
 }
 
@@ -56,15 +63,17 @@ class ReferenceConstructorTest : SingleFileTestFixture("references", "ReferenceC
     @Test fun `find reference to main constructor`() {
         val request = referenceParams(file, 1, 24)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
 
-        assertThat("Finds reference to the main constructor", references, hasItem(hasProperty("uri", containsString("ReferenceConstructor.kt"))))
+        assertThat("Finds reference to the main constructor", referenceStrs, hasItem(containsString("ReferenceConstructor.kt")))
     }
 
     @Test fun `find reference to secondary constructor`() {
         val request = referenceParams(file, 2, 10)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
 
-        assertThat("Finds reference to a secondary constructor", references, hasItem(hasProperty("uri", containsString("ReferenceConstructor.kt"))))
+        assertThat("Finds reference to a secondary constructor", referenceStrs, hasItem(containsString("ReferenceConstructor.kt")))
     }
 }
 
@@ -72,17 +81,21 @@ class ReferenceGetSetValueTest : SingleFileTestFixture("references", "ReferenceG
     @Test fun `find references to getValue`() {
         val request = referenceParams(file, 4, 21)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
-        assertThat(references, hasItem(hasToString(containsString("line = 8"))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat(referenceStrs, hasItem(containsString("line = 8")))
     }
 
     @Test fun `find references to setValue`() {
         val request = referenceParams(file, 5, 21)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
-        assertThat(references, hasItem(hasToString(containsString("line = 8"))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat(referenceStrs, hasItem(containsString("line = 8")))
     }
 }
 
@@ -90,17 +103,21 @@ class ReferenceGetterSetterTest : SingleFileTestFixture("references", "Reference
     @Test fun `find references to get`() {
         val request = referenceParams(file, 2, 19)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
-        assertThat(references, hasItem(hasToString(containsString("line = 7"))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat(referenceStrs, hasItem(containsString("line = 7")))
     }
 
     @Test fun `find references to set`() {
         val request = referenceParams(file, 3, 19)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
-        assertThat(references, hasItem(hasToString(containsString("line = 8"))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat(referenceStrs, hasItem(containsString("line = 8")))
     }
 }
 
@@ -108,9 +125,11 @@ class ReferenceInvokeTest : SingleFileTestFixture("references", "ReferenceInvoke
     @Test fun `find references to invoke`() {
         val request = referenceParams(file, 2, 21)
         val references = languageServer.textDocumentService.references(request).get()
+        val referenceStrs = references?.map { it.toString() }
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
-        assertThat(references, hasItem(hasToString(containsString("line = 6"))))
+        assertThat(uris, hasItem(containsString(file)))
+        assertThat(referenceStrs, hasItem(containsString("line = 6")))
     }
 }
 
@@ -118,57 +137,65 @@ class ReferenceOperatorTest : SingleFileTestFixture("references", "ReferenceOper
     @Test fun `find references to equals`() {
         val request = referenceParams(file, 2, 30)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to compareTo`() {
         val request = referenceParams(file, 3, 22)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to inc`() {
         val request = referenceParams(file, 4, 20)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to dec`() {
         val request = referenceParams(file, 5, 20)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to plus`() {
         val request = referenceParams(file, 6, 20)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to minus`() {
         val request = referenceParams(file, 7, 20)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to not`() {
         val request = referenceParams(file, 8, 20)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to equals without operator keyword`() {
         val request = referenceParams(file, 12, 21)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 }
 
@@ -176,21 +203,24 @@ class ReferenceOperatorUsingNameTest : SingleFileTestFixture("references", "Refe
     @Test fun `find references to equals`() {
         val request = referenceParams(file, 2, 30)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to compareTo`() {
         val request = referenceParams(file, 3, 22)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 
     @Test fun `find references to inc`() {
         val request = referenceParams(file, 4, 20)
         val references = languageServer.textDocumentService.references(request).get()
+        val uris = references?.map { it.uri }
 
-        assertThat(references, hasItem(hasProperty("uri", containsString(file))))
+        assertThat(uris, hasItem(containsString(file)))
     }
 }


### PR DESCRIPTION
Kotlin 1.4's type inference caused a regression since some matcher expressions could no longer be type-inferred.

This PR fixes the issue.