### PR TITLE
Remove workspace/symbol request size restriction.

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/symbols/Symbols.kt
+++ b/server/src/main/kotlin/org/javacs/kt/symbols/Symbols.kt
@@ -30,13 +30,10 @@ private fun doDocumentSymbols(element: PsiElement): List<DocumentSymbol> {
     } ?: children
 }
 
-private const val MAX_SYMBOLS = 50
-
 fun workspaceSymbols(query: String, sp: SourcePath): List<SymbolInformation> =
         doWorkspaceSymbols(sp)
                 .filter { containsCharactersInOrder(it.name!!, query, false) }
                 .mapNotNull(::symbolInformation)
-                .take(MAX_SYMBOLS)
                 .toList()
 
 private fun doWorkspaceSymbols(sp: SourcePath): Sequence<KtNamedDeclaration> =


### PR DESCRIPTION
This commit removes an arbitrary restriction of 50 symbols on the
workspace/symbol request in favor of spec compliance (no restriction).