### PR TITLE
Use compileClasspath for listing project dependencies

### DIFF
--- a/server/src/main/resources/projectClassPathFinder.gradle
+++ b/server/src/main/resources/projectClassPathFinder.gradle
@@ -44,26 +44,9 @@ allprojects { project ->
 				}
 			} else {
 				// Print the list of all dependencies jar files.
-				project.configurations.findAll {
-					it.metaClass.respondsTo(it, "isCanBeResolved") ? it.isCanBeResolved() : false
-				}.each {
-					it.resolve().each {
-						def inspected = it.inspect()
-
-						if (inspected.endsWith("jar")) {
-							if (!inspected.contains("zip!")) {
-								System.out.println "kotlin-lsp-gradle $it"
-							}
-						} else if (inspected.endsWith("aar")) {
-							// If the dependency is an AAR file we try to determine the location
-							// of the classes.jar file in the exploded aar folder.
-							def splitted = inspected.split("/")
-							def namespace = splitted[-5]
-							def name = splitted[-4]
-							def version = splitted[-3]
-							def explodedPath = "$project.buildDir/intermediates/exploded-aar/$namespace/$name/$version/jars/classes.jar"
-							System.out.println "kotlin-lsp-gradle $explodedPath"
-						}
+				sourceSets.forEach {
+					it.compileClasspath.forEach {
+						System.out.println "kotlin-lsp-gradle $it"
 					}
 				}
 			}


### PR DESCRIPTION
This change resolves #182 on my end.

**WARNING:** I cannot ascertain if this change would work correctly in all cases, especially as some functionality was removed. Feel free to point out any cases I might have missed.

One thing I noticed is that all of the project's compiled classes get added to the classpath after this change (which is kind of the point, as protobuf generated classes are also there). I have not observed any negative effects of this so far.