### PR TITLE
Fix ShellClassPathResolver on Windows +README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,24 @@ There are two hard parts of implementing a language server:
 
 The project uses the internal APIs of the [Kotlin compiler](https://github.com/JetBrains/kotlin/tree/master/compiler).
 
-Dependencies are determined by the [findClassPath](server/src/main/kotlin/org/javacs/kt/classpath/findClassPath.kt) function, which invokes Maven or Gradle and tells it to output a list of dependencies. Currently, both Maven and Gradle projects are supported.
+
+### Figuring out the dependencies 
+
+Dependencies are determined by the [DefaultClassPathResolver.kt](shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt), which invokes Maven, Gradle or `$HOME/.config/KotlinLanguageServer/classpath.{sh,bat,cmd}` and tells it to output a list of dependencies.
+
+* Example of the `~/.config/KotlinLanguageServer/classpath.sh` on Linux:
+```bash
+#!/bin/bash
+echo /my/path/kotlin-compiler-1.4.10/lib/kotlin-stdlib.jar:/my/path/my-lib.jar
+```
+
+* Example of the `%HOMEPATH%\.config\KotlinLanguageServer\classpath.bat` on Windows:
+```cmd
+@echo off
+echo C:\my\path\kotlin-compiler-1.4.10\lib\kotlin-stdlib.jar;C:\my\path\my-lib.jar
+```
+
+### Incrementally re-compiling as the user types
 
 I get incremental compilation at the file-level by keeping the same `KotlinCoreEnvironment` alive between compilations in [Compiler.kt](server/src/main/kotlin/org/javacs/kt/Compiler.kt). There is a performance benchmark in [OneFilePerformance.kt](server/src/test/kotlin/org/javacs/kt/OneFilePerformance.kt) that verifies this works.
 

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathResolver.kt
@@ -1,5 +1,6 @@
 package org.javacs.kt.classpath
 
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -19,7 +20,7 @@ internal class ShellClassPathResolver(
         val process = Runtime.getRuntime().exec(cmd, null, workingDirectory)
 
         return process.inputStream.bufferedReader().readText()
-            .split(':')
+            .split(File.pathSeparator)
             .asSequence()
             .map { it.trim() }
             .filter { it.isNotEmpty() }
@@ -38,8 +39,11 @@ internal class ShellClassPathResolver(
 
         /** Returns the ShellClassPathResolver for the global home directory shell script. */
         fun global(workingDir: Path?): ClassPathResolver =
-            globalConfigRoot.resolve("KotlinLanguageServer").resolve("classpath.sh")
-                .takeIf { Files.exists(it) }
+            globalConfigRoot.resolve("KotlinLanguageServer")?.let {
+                    it.resolve("classpath.sh").takeIf { Files.exists(it) } ?:
+                    it.resolve("classpath.bat").takeIf { Files.exists(it) } ?:
+                    it.resolve("classpath.cmd").takeIf { Files.exists(it) }
+                }
                 ?.let { ShellClassPathResolver(it, workingDir) }
                 ?: ClassPathResolver.empty
     }


### PR DESCRIPTION
Teach ShellClassPathResolver how to get classpath from
classpath.bat or classpath.cmd on Windows.

Improve README.md describing how to use ShellClassPathResolver
on Linux and Windows.

Fix broken URL for classpath resolution.