### PR TITLE
Add support for getting classpath from kscript kts

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt
@@ -59,4 +59,5 @@ private fun ignoredPathPatterns(path: Path): List<PathMatcher> =
 private fun asClassPathProvider(path: Path): ClassPathResolver? =
     MavenClassPathResolver.maybeCreate(path)
         ?: GradleClassPathResolver.maybeCreate(path)
+        ?: KScriptClassPathResolver.maybeCreate(path)
         ?: ShellClassPathResolver.maybeCreate(path)

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/KScriptClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/KScriptClassPathResolver.kt
@@ -1,0 +1,39 @@
+package org.javacs.kt.classpath
+
+import org.javacs.kt.LOG
+import java.nio.file.Path
+
+/** Resolver for reading maven dependencies */
+internal class KScriptClassPathResolver private constructor(private val script: Path) : ClassPathResolver {
+    override val resolverType: String = "KScript"
+    override val classpath: Set<Path> get() {
+        val artifacts = readKScriptDependencyList(script)
+
+        when {
+            artifacts.isEmpty() -> LOG.warn("No artifacts found in {}", script)
+            artifacts.size < 5 -> LOG.info("Found {} in {}", artifacts, script)
+            else -> LOG.info("Found {} artifacts in {}", artifacts.size, script)
+        }
+
+        return artifacts.mapNotNull { findMavenArtifact(it, false) }.toSet()
+    }
+
+    companion object {
+        /** Create a maven resolver if a file is a pom. */
+        fun maybeCreate(file: Path): KScriptClassPathResolver? =
+            file.takeIf {
+                it.toString().endsWith("kts") &&
+                    it.toFile().bufferedReader().use { b -> b.readLine().contains("kscript") }
+            }?.let { KScriptClassPathResolver(file) }
+    }
+}
+
+private val artifactPattern = "^//DEPS .*".toRegex()
+
+private fun readKScriptDependencyList(script: Path): Set<Artifact> =
+    script.toFile()
+        .readLines()
+        .filter { artifactPattern.matches(it) }
+        .flatMap { it.substring("//DEPS ".length).split(",") }
+        .map { parseMavenArtifact(it) }
+        .toSet()

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
@@ -40,7 +40,7 @@ private fun readMavenDependencyList(mavenOutput: Path): Set<Artifact> =
         .map { parseMavenArtifact(it) }
         .toSet()
 
-private fun findMavenArtifact(a: Artifact, source: Boolean): Path? {
+internal fun findMavenArtifact(a: Artifact, source: Boolean): Path? {
     val result = mavenHome.resolve("repository")
         .resolve(a.group.replace('.', File.separatorChar))
         .resolve(a.artifact)


### PR DESCRIPTION
It acts pretty much like Maven, using most of the same resolution
logic, but reads the targets from the script file with a prefix of
"//DEPS ".