### PR TITLE
Update LSP4J to 0.10.0 and tag diagnostics

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,9 +29,9 @@ dependencies {
     implementation project(':shared')
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.10.0'
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.10.0'
-    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-scripting-compiler:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-impl:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-scripting-jvm-host-unshaded:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     implementation "org.jetbrains.kotlin:ide-common-ij201:$kotlinVersion"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -23,6 +23,7 @@ startScripts {
 
 repositories {
     maven { url uri("$projectDir/lib") }
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -37,7 +38,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:ide-common-ij201:$kotlinVersion"
     // implementation("org.jetbrains.kotlin:kotlin-plugin-ij201:$kotlinVersion") { transitive = false }
     implementation 'org.jetbrains:fernflower:1.0'
-    implementation 'com.facebook:ktfmt:0.19'
+    implementation 'com.github.fwcd:ktfmt:22bd538a1c'
     implementation 'com.beust:jcommander:1.78'
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,8 +27,8 @@ repositories {
 
 dependencies {
     implementation project(':shared')
-    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.7.0'
-    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.7.0'
+    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.10.0'
+    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.10.0'
     implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:$kotlinVersion"

--- a/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
@@ -1,8 +1,8 @@
 package org.javacs.kt
 
-import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiIdentifier
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiIdentifier
 import org.javacs.kt.position.changedRegion
 import org.javacs.kt.position.position
 import org.javacs.kt.util.findParent

--- a/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
@@ -3,6 +3,7 @@ package org.javacs.kt
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiIdentifier
+import org.javacs.kt.compiler.CompilationKind
 import org.javacs.kt.position.changedRegion
 import org.javacs.kt.position.position
 import org.javacs.kt.util.findParent

--- a/server/src/main/kotlin/org/javacs/kt/Compiler.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Compiler.kt
@@ -1,15 +1,15 @@
 package org.javacs.kt
 
-import org.jetbrains.kotlin.com.intellij.codeInsight.NullableNotNullManager
-import org.jetbrains.kotlin.com.intellij.lang.Language
-import org.jetbrains.kotlin.com.intellij.openapi.Disposable
-import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.StandardFileSystems
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileManager
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileSystem
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
-import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
-import org.jetbrains.kotlin.com.intellij.mock.MockProject
+import com.intellij.codeInsight.NullableNotNullManager
+import com.intellij.lang.Language
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.VirtualFileSystem
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.mock.MockProject
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
 import org.jetbrains.kotlin.cli.jvm.compiler.CliBindingTrace

--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -1,6 +1,7 @@
 package org.javacs.kt
 
 import org.javacs.kt.classpath.defaultClassPathResolver
+import org.javacs.kt.compiler.Compiler
 import java.io.Closeable
 import java.nio.file.Files
 import java.nio.file.FileSystems

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -102,7 +102,7 @@ class KotlinTextDocumentService(
         }
     }
 
-    override fun hover(position: TextDocumentPositionParams): CompletableFuture<Hover?> = async.compute {
+    override fun hover(position: HoverParams): CompletableFuture<Hover?> = async.compute {
         reportTime {
             LOG.info("Hovering at {}", describePosition(position))
 
@@ -111,7 +111,7 @@ class KotlinTextDocumentService(
         }
     }
 
-    override fun documentHighlight(position: TextDocumentPositionParams): CompletableFuture<List<DocumentHighlight>> {
+    override fun documentHighlight(position: DocumentHighlightParams): CompletableFuture<List<DocumentHighlight>> {
         TODO("not implemented")
     }
 
@@ -119,7 +119,7 @@ class KotlinTextDocumentService(
         TODO("not implemented")
     }
 
-    override fun definition(position: TextDocumentPositionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> = async.compute {
+    override fun definition(position: DefinitionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> = async.compute {
         reportTime {
             LOG.info("Go-to-definition at {}", describePosition(position))
 
@@ -190,7 +190,7 @@ class KotlinTextDocumentService(
         lintNow(uri)
     }
 
-    override fun signatureHelp(position: TextDocumentPositionParams): CompletableFuture<SignatureHelp?> = async.compute {
+    override fun signatureHelp(position: SignatureHelpParams): CompletableFuture<SignatureHelp?> = async.compute {
         reportTime {
             LOG.info("Signature help at {}", describePosition(position))
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -1,6 +1,6 @@
 package org.javacs.kt
 
-import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import com.intellij.openapi.project.Project
 import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.services.WorkspaceService
 import org.eclipse.lsp4j.services.LanguageClient

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -207,7 +207,11 @@ private fun patch(sourceText: String, change: TextDocumentContentChangeEvent): S
     for (i in 0 until (range.end.line - range.start.line)) {
         reader.readLine()
     }
-    reader.skip(range.end.character.toLong())
+    if (range.start.line == range.end.line) {
+        reader.skip((range.end.character - range.start.character).toLong())
+    } else {
+        reader.skip(range.end.character.toLong())
+    }
 
     // Write remaining text
     while (true) {

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -196,14 +196,18 @@ private fun patch(sourceText: String, change: TextDocumentContentChangeEvent): S
     }
 
     // Skip unchanged chars
-    for (character in 0 until range.start.character)
+    for (character in 0 until range.start.character) {
         writer.write(reader.read())
+    }
 
     // Write replacement text
     writer.write(change.text)
 
     // Skip replaced text
-    reader.skip(change.rangeLength!!.toLong())
+    for (i in 0 until (range.end.line - range.start.line)) {
+        reader.readLine()
+    }
+    reader.skip(range.end.character.toLong())
 
     // Write remaining text
     while (true) {

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -1,8 +1,8 @@
 package org.javacs.kt
 
-import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtil.convertLineSeparators
-import org.jetbrains.kotlin.com.intellij.lang.java.JavaLanguage
-import org.jetbrains.kotlin.com.intellij.lang.Language
+import com.intellij.openapi.util.text.StringUtil.convertLineSeparators
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.lang.Language
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent
 import org.javacs.kt.util.KotlinLSException

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -1,5 +1,6 @@
 package org.javacs.kt
 
+import org.javacs.kt.compiler.CompilationKind
 import org.javacs.kt.util.fileExtension
 import org.javacs.kt.util.filePath
 import org.javacs.kt.util.describeURI

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -3,8 +3,8 @@ package org.javacs.kt
 import org.javacs.kt.util.fileExtension
 import org.javacs.kt.util.filePath
 import org.javacs.kt.util.describeURI
-import org.jetbrains.kotlin.com.intellij.lang.Language
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import com.intellij.lang.Language
+import com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext

--- a/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
+++ b/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
@@ -1,4 +1,4 @@
-package org.javacs.kt
+package org.javacs.kt.compiler
 
 import com.intellij.codeInsight.NullableNotNullManager
 import com.intellij.lang.Language
@@ -76,6 +76,8 @@ import kotlin.script.experimental.host.ScriptingHostConfiguration
 import kotlin.script.experimental.host.configurationDependencies
 import kotlin.script.experimental.jvm.defaultJvmScriptingHostConfiguration
 import kotlin.script.experimental.jvm.JvmDependency
+import org.javacs.kt.LOG
+import org.javacs.kt.CompilerConfiguration
 import org.javacs.kt.util.KotlinLSException
 import org.javacs.kt.util.LoggingMessageCollector
 

--- a/server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt
+++ b/server/src/main/kotlin/org/javacs/kt/diagnostic/ConvertDiagnostic.kt
@@ -2,6 +2,7 @@ package org.javacs.kt.diagnostic
 
 import org.eclipse.lsp4j.DiagnosticSeverity
 import org.eclipse.lsp4j.Diagnostic as LangServerDiagnostic
+import org.eclipse.lsp4j.DiagnosticTag
 import org.javacs.kt.position.range
 import org.javacs.kt.util.toPath
 import org.jetbrains.kotlin.diagnostics.Severity
@@ -16,11 +17,18 @@ fun convertDiagnostic(diagnostic: KotlinDiagnostic): List<Pair<URI, LangServerDi
 
     return diagnostic.textRanges.map {
         val d = LangServerDiagnostic(
-                range(content, it),
-                message(diagnostic),
-                severity(diagnostic.severity),
-                "kotlin",
-                code(diagnostic))
+            range(content, it),
+            message(diagnostic),
+            severity(diagnostic.severity),
+            "kotlin",
+            code(diagnostic)
+        ).apply {
+            val factoryName = diagnostic.factory.name
+            tags = mutableListOf<DiagnosticTag>()
+
+            if ("UNUSED_VARIABLE" in factoryName) tags.add(DiagnosticTag.Unnecessary)
+            if ("DEPRECATION"     in factoryName) tags.add(DiagnosticTag.Deprecated)
+        }
         Pair(uri, d)
     }
 }

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaElementConverter.kt
@@ -1,8 +1,8 @@
 package org.javacs.kt.j2k
 
 import org.javacs.kt.LOG
-import org.jetbrains.kotlin.com.intellij.psi.*
-import org.jetbrains.kotlin.com.intellij.psi.javadoc.*
+import com.intellij.psi.*
+import com.intellij.psi.javadoc.*
 
 /**
  * A Psi visitor that converts Java elements into

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
@@ -1,8 +1,8 @@
 package org.javacs.kt.j2k
 
-import org.jetbrains.kotlin.com.intellij.lang.java.JavaLanguage
-import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
-import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.psi.PsiFileFactory
+import com.intellij.openapi.project.Project
 // import org.jetbrains.kotlin.j2k.JavaToKotlinTranslator
 import org.javacs.kt.LOG
 import org.javacs.kt.Compiler

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaToKotlinConverter.kt
@@ -5,8 +5,8 @@ import com.intellij.psi.PsiFileFactory
 import com.intellij.openapi.project.Project
 // import org.jetbrains.kotlin.j2k.JavaToKotlinTranslator
 import org.javacs.kt.LOG
-import org.javacs.kt.Compiler
-import org.javacs.kt.CompilationKind
+import org.javacs.kt.compiler.Compiler
+import org.javacs.kt.compiler.CompilationKind
 import org.javacs.kt.util.nonNull
 
 fun convertJavaToKotlin(javaCode: String, compiler: Compiler): String {

--- a/server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/j2k/JavaTypeConverter.kt
@@ -1,7 +1,7 @@
 package org.javacs.kt.j2k
 
 import org.javacs.kt.LOG
-import org.jetbrains.kotlin.com.intellij.psi.*
+import com.intellij.psi.*
 
 object JavaTypeConverter : PsiTypeVisitor<String>() {
     override fun visitType(type: PsiType): String {

--- a/server/src/main/kotlin/org/javacs/kt/position/Position.kt
+++ b/server/src/main/kotlin/org/javacs/kt/position/Position.kt
@@ -1,8 +1,8 @@
 package org.javacs.kt.position
 
-import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range

--- a/server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt
+++ b/server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt
@@ -28,14 +28,14 @@ fun fetchSignatureHelpAt(file: CompiledFile, cursor: Int): SignatureHelp? {
 
 /**
  * Returns the doc string of the first found CallableDescriptor
- * 
+ *
  * Avoids fetching the SignatureHelp triplet due to an OutOfBoundsException that can occur due to the offset difference math.
  * When hovering, the cursor param is set to the doc offset where the mouse is hovering over, rather than where the actual cursor is,
  * hence this is seen to cause issues when slicing the param list string
  */
 fun getDocString(file: CompiledFile, cursor: Int): String {
     val signatures = getSignatures(file, cursor)
-    if (signatures == null || signatures.size == 0 || signatures[0].documentation == null) 
+    if (signatures == null || signatures.size == 0 || signatures[0].documentation == null)
         return ""
     return if (signatures[0].documentation.isLeft()) signatures[0].documentation.left else ""
 }

--- a/server/src/main/kotlin/org/javacs/kt/symbols/Symbols.kt
+++ b/server/src/main/kotlin/org/javacs/kt/symbols/Symbols.kt
@@ -1,6 +1,6 @@
 package org.javacs.kt.symbols
 
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElement
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.SymbolInformation
 import org.eclipse.lsp4j.SymbolKind

--- a/server/src/main/kotlin/org/javacs/kt/util/PsiUtils.kt
+++ b/server/src/main/kotlin/org/javacs/kt/util/PsiUtils.kt
@@ -1,8 +1,8 @@
 package org.javacs.kt.util
 
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import java.nio.file.Path
 
 inline fun<reified Find> PsiElement.findParent() =

--- a/server/src/test/kotlin/org/javacs/kt/AdditionalWorkspaceTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/AdditionalWorkspaceTest.kt
@@ -27,7 +27,7 @@ class AdditionalWorkspaceTest : LanguageServerTestFixture("mainWorkspace") {
         addWorkspaceRoot()
         open(file)
 
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 5, 14)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 5, 14)).get()!!
 
         assertThat(hover.contents.left, not(emptyList()))
         assertThat(hover.contents.left.first().right.value, containsString("fun assertTrue"))
@@ -37,11 +37,11 @@ class AdditionalWorkspaceTest : LanguageServerTestFixture("mainWorkspace") {
     @Test fun `recompile all when classpath changes`() {
         open(file)
 
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 5, 14)).get()
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 5, 14)).get()
         assertThat("No hover before JUnit is added to classpath", hover, nullValue())
 
         addWorkspaceRoot()
-        val hoverAgain = languageServer.textDocumentService.hover(textDocumentPosition(file, 5, 14)).get() ?: return fail("No hover")
+        val hoverAgain = languageServer.textDocumentService.hover(hoverParams(file, 5, 14)).get() ?: return fail("No hover")
         assertThat(hoverAgain.contents.left, not(emptyList()))
         assertThat(hoverAgain.contents.left.first().right.value, containsString("fun assertTrue"))
     }

--- a/server/src/test/kotlin/org/javacs/kt/CompilerFixtures.kt
+++ b/server/src/test/kotlin/org/javacs/kt/CompilerFixtures.kt
@@ -1,7 +1,7 @@
 package org.javacs.kt
 
-import org.jetbrains.kotlin.com.intellij.openapi.project.Project
-import org.jetbrains.kotlin.com.intellij.psi.search.GlobalSearchScope
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
 import org.jetbrains.kotlin.cli.jvm.compiler.JvmPackagePartProvider
 import org.jetbrains.kotlin.config.CompilerConfiguration

--- a/server/src/test/kotlin/org/javacs/kt/DefinitionTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/DefinitionTest.kt
@@ -14,7 +14,7 @@ class DefinitionTest : SingleFileTestFixture("definition", "GoFrom.kt") {
 
     @Test
     fun `go to a definition in the same file`() {
-        val definitions = languageServer.textDocumentService.definition(textDocumentPosition(file, 3, 24)).get().left
+        val definitions = languageServer.textDocumentService.definition(definitionParams(file, 3, 24)).get().left
         val uris = definitions.map { it.uri }
 
         assertThat(definitions, hasSize(1))
@@ -23,7 +23,7 @@ class DefinitionTest : SingleFileTestFixture("definition", "GoFrom.kt") {
 
     @Test
     fun `go to a definition in a different file`() {
-        val definitions = languageServer.textDocumentService.definition(textDocumentPosition(file, 4, 24)).get().left
+        val definitions = languageServer.textDocumentService.definition(definitionParams(file, 4, 24)).get().left
         val uris = definitions.map { it.uri }
 
         assertThat(definitions, hasSize(1))
@@ -67,7 +67,7 @@ class GoToDefinitionOfPropertiesTest : SingleFileTestFixture("definition", "GoTo
     }
 
     private fun assertGoToProperty(of: Position, expect: Range) {
-        val definitions = languageServer.textDocumentService.definition(textDocumentPosition(file, of)).get().left
+        val definitions = languageServer.textDocumentService.definition(definitionParams(file, of.line, of.character)).get().left
         val uris = definitions.map { it.uri }
         val ranges = definitions.map { it.range }
 

--- a/server/src/test/kotlin/org/javacs/kt/DefinitionTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/DefinitionTest.kt
@@ -67,7 +67,7 @@ class GoToDefinitionOfPropertiesTest : SingleFileTestFixture("definition", "GoTo
     }
 
     private fun assertGoToProperty(of: Position, expect: Range) {
-        val definitions = languageServer.textDocumentService.definition(definitionParams(file, of.line, of.character)).get().left
+        val definitions = languageServer.textDocumentService.definition(definitionParams(file, of)).get().left
         val uris = definitions.map { it.uri }
         val ranges = definitions.map { it.range }
 

--- a/server/src/test/kotlin/org/javacs/kt/GradleDSLScriptTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/GradleDSLScriptTest.kt
@@ -14,7 +14,7 @@ class GradleDSLScriptTest : SingleFileTestFixture("kotlinDSLWorkspace", "build.g
     }
 
     @Test fun `hover plugin`() {
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 4, 8)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 4, 8)).get()!!
         val contents = hover.contents.left.first().right
 
         assertThat(contents, equalTo(MarkedString("kotlin", "fun PluginDependenciesSpec.kotlin(module: String): PluginDependencySpec")))

--- a/server/src/test/kotlin/org/javacs/kt/GradleDSLScriptTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/GradleDSLScriptTest.kt
@@ -3,7 +3,7 @@ package org.javacs.kt
 import org.junit.Test
 import org.junit.Assert.assertThat
 import org.hamcrest.Matchers.*
-import org.eclipse.lsp4j.MarkedString
+import org.eclipse.lsp4j.MarkupContent
 
 class GradleDSLScriptTest : SingleFileTestFixture("kotlinDSLWorkspace", "build.gradle.kts") {
     @Test fun `edit repositories`() {
@@ -17,6 +17,6 @@ class GradleDSLScriptTest : SingleFileTestFixture("kotlinDSLWorkspace", "build.g
         val hover = languageServer.textDocumentService.hover(hoverParams(file, 4, 8)).get()!!
         val contents = hover.contents.left.first().right
 
-        assertThat(contents, equalTo(MarkedString("kotlin", "fun PluginDependenciesSpec.kotlin(module: String): PluginDependencySpec")))
+        assertThat(contents, equalTo(MarkupContent("kotlin", "fun PluginDependenciesSpec.kotlin(module: String): PluginDependencySpec")))
     }
 }

--- a/server/src/test/kotlin/org/javacs/kt/HoverTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/HoverTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class HoverLiteralsTest : SingleFileTestFixture("hover", "Literals.kt") {
     @Test fun `string reference`() {
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 3, 19)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 3, 19)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)
@@ -15,7 +15,7 @@ class HoverLiteralsTest : SingleFileTestFixture("hover", "Literals.kt") {
 
 class HoverFunctionReferenceTest : SingleFileTestFixture("hover", "FunctionReference.kt") {
     @Test fun `function reference`() {
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 2, 45)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 2, 45)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)
@@ -25,7 +25,7 @@ class HoverFunctionReferenceTest : SingleFileTestFixture("hover", "FunctionRefer
 
 class HoverObjectReferenceTest : SingleFileTestFixture("hover", "ObjectReference.kt") {
     @Test fun `object reference`() {
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 2, 7)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 2, 7)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)
@@ -33,7 +33,7 @@ class HoverObjectReferenceTest : SingleFileTestFixture("hover", "ObjectReference
     }
 
     @Test fun `object reference with incomplete method`() {
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 6, 7)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 6, 7)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)
@@ -41,7 +41,7 @@ class HoverObjectReferenceTest : SingleFileTestFixture("hover", "ObjectReference
     }
 
     @Test fun `object reference with method`() {
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 10, 7)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 10, 7)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)
@@ -49,7 +49,7 @@ class HoverObjectReferenceTest : SingleFileTestFixture("hover", "ObjectReference
     }
 
     @Test fun `object method`() {
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 10, 15)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 10, 15)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)
@@ -61,7 +61,7 @@ class HoverRecoverTest : SingleFileTestFixture("hover", "Recover.kt") {
     @Test fun `incrementally repair a single-expression function`() {
         replace(file, 2, 9, "\"Foo\"", "intFunction()")
 
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 2, 11)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 2, 11)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)
@@ -71,7 +71,7 @@ class HoverRecoverTest : SingleFileTestFixture("hover", "Recover.kt") {
     @Test fun `incrementally repair a block function`() {
         replace(file, 5, 13, "\"Foo\"", "intFunction()")
 
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(file, 5, 13)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(file, 5, 13)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)
@@ -86,7 +86,7 @@ class HoverAcrossFilesTest : LanguageServerTestFixture("hover") {
         open(from)
         open(to)
 
-        val hover = languageServer.textDocumentService.hover(textDocumentPosition(from, 3, 26)).get()!!
+        val hover = languageServer.textDocumentService.hover(hoverParams(from, 3, 26)).get()!!
         val contents = hover.contents.left.first().right
 
         assertEquals("kotlin", contents.language)

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -38,11 +38,11 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
 
         return languageServer
     }
-    
+
     @After fun closeLanguageServer() {
         languageServer.close()
     }
-    
+
     @After fun printMemoryUsage() {
         val rt = Runtime.getRuntime()
         val total = rt.totalMemory().toDouble() / 1000000.0
@@ -58,9 +58,17 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
         return CompletionParams(fileId, position)
     }
 
-    fun textDocumentPosition(relativePath: String, line: Int, column: Int): TextDocumentPositionParams {
-        return textDocumentPosition(relativePath, position(line, column))
-    }
+    fun textDocumentPosition(relativePath: String, line: Int, column: Int): TextDocumentPositionParams =
+        textDocumentPosition(relativePath, position(line, column))
+
+    fun hoverParams(relativePath: String, line: Int, column: Int): HoverParams =
+        textDocumentPosition(relativePath, line, column).run { HoverParams(textDocument, position) }
+
+    fun signatureHelpParams(relativePath: String, line: Int, column: Int): SignatureHelpParams =
+        textDocumentPosition(relativePath, line, column).run { SignatureHelpParams(textDocument, position) }
+
+    fun definitionParams(relativePath: String, line: Int, column: Int): DefinitionParams =
+        textDocumentPosition(relativePath, line, column).run { DefinitionParams(textDocument, position) }
 
     fun textDocumentPosition(relativePath: String, position: Position): TextDocumentPositionParams {
         val file = workspaceRoot.resolve(relativePath)
@@ -76,12 +84,12 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
     fun uri(relativePath: String) =
             workspaceRoot.resolve(relativePath).toUri()
 
-    fun referenceParams(relativePath: String, line: Int, column: Int): ReferenceParams {
-        val request = ReferenceParams(ReferenceContext(true))
-        request.textDocument = TextDocumentIdentifier(uri(relativePath).toString())
-        request.position = position(line, column)
-        return request
-    }
+    fun referenceParams(relativePath: String, line: Int, column: Int): ReferenceParams =
+        ReferenceParams(
+            TextDocumentIdentifier(uri(relativePath).toString()),
+            position(line, column),
+            ReferenceContext(true)
+        )
 
     fun open(relativePath: String) {
         val file =  workspaceRoot.resolve(relativePath)
@@ -119,7 +127,7 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
     override fun logMessage(message: MessageParams?) = printMessage(message)
 
     override fun showMessage(message: MessageParams?) = printMessage(message)
-    
+
     private fun printMessage(message: MessageParams?) {
         println("[${message?.type}] ${message?.message}")
     }

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -70,6 +70,9 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
     fun definitionParams(relativePath: String, line: Int, column: Int): DefinitionParams =
         textDocumentPosition(relativePath, line, column).run { DefinitionParams(textDocument, position) }
 
+    fun definitionParams(relativePath: String, position: Position): DefinitionParams =
+        textDocumentPosition(relativePath, position).run { DefinitionParams(textDocument, position) }
+
     fun textDocumentPosition(relativePath: String, position: Position): TextDocumentPositionParams {
         val file = workspaceRoot.resolve(relativePath)
         val fileId = TextDocumentIdentifier(file.toUri().toString())

--- a/server/src/test/kotlin/org/javacs/kt/OneFilePerformance.kt
+++ b/server/src/test/kotlin/org/javacs/kt/OneFilePerformance.kt
@@ -5,11 +5,11 @@ import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.jvm.compiler.CliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.StandardFileSystems
-import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileManager
-import org.jetbrains.kotlin.com.intellij.psi.PsiManager
-import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.psi.PsiManager
+import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil

--- a/server/src/test/kotlin/org/javacs/kt/SignatureHelpTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/SignatureHelpTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 class SignatureHelpTest : SingleFileTestFixture("signatureHelp", "SignatureHelp.kt") {
     @Test fun `provide signature help for a function call`() {
-        val help = languageServer.textDocumentService.signatureHelp(textDocumentPosition(file, 3, 20)).get()!!
+        val help = languageServer.textDocumentService.signatureHelp(signatureHelpParams(file, 3, 20)).get()!!
 
         assertThat(help.signatures, hasSize(2))
         assertThat(help.activeParameter, equalTo(0))
@@ -19,7 +19,7 @@ class SignatureHelpTest : SingleFileTestFixture("signatureHelp", "SignatureHelp.
     }
 
     @Test fun `provide signature help for a constructor`() {
-        val help = languageServer.textDocumentService.signatureHelp(textDocumentPosition(file, 4, 21)).get()!!
+        val help = languageServer.textDocumentService.signatureHelp(signatureHelpParams(file, 4, 21)).get()!!
 
         assertThat(help.signatures, hasSize(2))
         assertThat(help.activeParameter, equalTo(0))
@@ -31,25 +31,25 @@ class SignatureHelpTest : SingleFileTestFixture("signatureHelp", "SignatureHelp.
     }
 
     @Test fun `find active parameter`() {
-        val help = languageServer.textDocumentService.signatureHelp(textDocumentPosition(file, 5, 32)).get()!!
+        val help = languageServer.textDocumentService.signatureHelp(signatureHelpParams(file, 5, 32)).get()!!
 
         assertThat(help.activeParameter, equalTo(1))
     }
 
     @Test fun `find active parameter in the middle of list`() {
-        val help = languageServer.textDocumentService.signatureHelp(textDocumentPosition(file, 5, 30)).get()!!
+        val help = languageServer.textDocumentService.signatureHelp(signatureHelpParams(file, 5, 30)).get()!!
 
         assertThat(help.activeParameter, equalTo(0))
     }
 
     @Ignore @Test fun `find active signature using types`() {
-        val help = languageServer.textDocumentService.signatureHelp(textDocumentPosition(file, 5, 32)).get()!!
+        val help = languageServer.textDocumentService.signatureHelp(signatureHelpParams(file, 5, 32)).get()!!
 
         assertThat(help.signatures[help.activeSignature].label, equalTo("fun multiParam(first: String, second: String): Unit"))
     }
 
     @Test fun `find active signature using number of arguments`() {
-        val help = languageServer.textDocumentService.signatureHelp(textDocumentPosition(file, 6, 34)).get()!!
+        val help = languageServer.textDocumentService.signatureHelp(signatureHelpParams(file, 6, 34)).get()!!
 
         assertThat(help.signatures[help.activeSignature].label, equalTo("fun oneOrTwoArgs(first: String, second: String): Unit"))
     }


### PR DESCRIPTION
Tagged diagnostics let language servers attach richer semantic information to diagnostics, e.g. unused variable and deprecation warnings:

![image](https://user-images.githubusercontent.com/30873659/103163724-230b2700-4802-11eb-8d8c-de99ec96c56e.png)
