### PR TITLE
Walk the file tree lazily while looking for resolvers

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt
@@ -19,21 +19,12 @@ private fun workspaceResolvers(workspaceRoot: Path): Sequence<ClassPathResolver>
 }
 
 /** Searches the folder for all build-files. */
-private fun folderResolvers(root: Path, ignored: List<PathMatcher>): Collection<ClassPathResolver> {
-    val resolvers = mutableListOf<ClassPathResolver>()
-
-    for (file in Files.walk(root)) {
-        // Only test whether non-ignored file is a build-file
-        if (ignored.none { it.matches(root.relativize(file)) }) {
-            val resolver = asClassPathProvider(file)
-            if (resolver != null) {
-                resolvers.add(resolver)
-            }
-        }
-    }
-
-    return resolvers
-}
+private fun folderResolvers(root: Path, ignored: List<PathMatcher>): Collection<ClassPathResolver> =
+    root.toFile()
+        .walk()
+        .onEnter { file -> ignored.none { it.matches(root.relativize(file.toPath())) } }
+        .mapNotNull { asClassPathProvider(it.toPath()) }
+        .toList()
 
 /** Tries to read glob patterns from a gitignore. */
 private fun ignoredPathPatterns(path: Path): List<PathMatcher> =


### PR DESCRIPTION
### Fixes #248 

This branch rewrites the file walker that looks for build files in a projects to be lazier by cutting off entire branches when finding an ignored pattern.