### PR TITLE
fix slow filewalk in some projects

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/DefaultClassPathResolver.kt
@@ -3,7 +3,6 @@ package org.javacs.kt.classpath
 import org.javacs.kt.LOG
 import java.nio.file.Path
 import java.nio.file.PathMatcher
-import java.nio.file.Files
 import java.nio.file.FileSystems
 
 fun defaultClassPathResolver(workspaceRoots: Collection<Path>): ClassPathResolver =
@@ -14,7 +13,7 @@ fun defaultClassPathResolver(workspaceRoots: Collection<Path>): ClassPathResolve
 
 /** Searches the workspace for all files that could provide classpath info. */
 private fun workspaceResolvers(workspaceRoot: Path): Sequence<ClassPathResolver> {
-    val ignored: List<PathMatcher> = ignoredPathPatterns(workspaceRoot.resolve(".gitignore"))
+    val ignored: List<PathMatcher> = ignoredPathPatterns(workspaceRoot, workspaceRoot.resolve(".gitignore"))
     return folderResolvers(workspaceRoot, ignored).asSequence()
 }
 
@@ -22,29 +21,30 @@ private fun workspaceResolvers(workspaceRoot: Path): Sequence<ClassPathResolver>
 private fun folderResolvers(root: Path, ignored: List<PathMatcher>): Collection<ClassPathResolver> =
     root.toFile()
         .walk()
-        .onEnter { file -> ignored.none { it.matches(root.relativize(file.toPath())) } }
+        .onEnter { file -> ignored.none { it.matches(file.toPath()) } }
         .mapNotNull { asClassPathProvider(it.toPath()) }
         .toList()
 
 /** Tries to read glob patterns from a gitignore. */
-private fun ignoredPathPatterns(path: Path): List<PathMatcher> =
-    path.toFile()
+private fun ignoredPathPatterns(root: Path, gitignore: Path): List<PathMatcher> =
+    gitignore.toFile()
         .takeIf { it.exists() }
         ?.readLines()
         ?.map { it.trim() }
         ?.filter { it.isNotEmpty() && !it.startsWith("#") }
+        ?.map { it.removeSuffix("/") }
         ?.let { it + listOf(
             // Patterns that are ignored by default
             ".git"
         ) }
         ?.mapNotNull { try {
-            LOG.debug("Adding ignore pattern '{}' from {}", it, path)
-            FileSystems.getDefault().getPathMatcher("glob:$it")
+            LOG.debug("Adding ignore pattern '{}' from {}", it, gitignore)
+            FileSystems.getDefault().getPathMatcher("glob:$root**/$it")
         } catch (e: Exception) {
             LOG.warn("Did not recognize gitignore pattern: '{}' ({})", it, e.message)
             null
         } }
-        ?: emptyList<PathMatcher>()
+        ?: emptyList()
 
 /** Tries to create a classpath resolver from a file using as many sources as possible */
 private fun asClassPathProvider(path: Path): ClassPathResolver? =


### PR DESCRIPTION
This closes #248 

As it is, with a `.gitignore`-file containing eg. `target`, it would ignore the folder `<the-repo>/target`, but not `<the-repo>/moduleA/target`. Added zero-or more glob dir-matcher `**` to fix this.

Also, `.gitignore` may have a `/` suffix, which will not match a Path to the same folder. Added removal of this suffix.

I tested `defaultClassPathResolver(listOf(Paths.get("/path/to/problem/repo"))).classpath`:

Before change: 1 min, 45 s

After change: 7 s

It's still possible to decrease this even further. Some ideas for:
- The code runs `mvn dependency:list -DincludeScope=test` for every `pom.xml` that is not in an ignored directory. For multimodule project, only the root-pom needs to be run, as this will find deps for all modules.
- mvn commands are usually a lot slower than parsing the xml-files manually, and as long as one does not have any 'used undecleared'-deps, that would be sufficient