### PR TITLE
Refactor gradleHome to check for GRADLE_USER_HOME first

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
@@ -1,6 +1,8 @@
 package org.javacs.kt.classpath
 
 import org.javacs.kt.util.userHome
+import java.nio.file.Paths
 
-internal val gradleHome = userHome.resolve(".gradle")
+internal val gradleHome = System.getenv("GRADLE_USER_HOME")?.let { Paths.get(it) } ?: userHome.resolve(".gradle")
+// TODO: try and figure out if mavenHome is in non-default position (requires finding and parsing settings.xml)
 internal val mavenHome = userHome.resolve(".m2")


### PR DESCRIPTION
Gradle users can specify where gradle lives via `$GRADLE_USER_HOME`. When this is done, the classpath resolver doesn't check the location set by the env var, but only the default location. This results in a failed build if kotlin is not on `$PATH`.

This PR fixes that by checking for `$GRADLE_USER_HOME` first, and falling back to the default `~/.gradle` if it's not set.

To see the change in action, open [the base repo in gitpod](https://gitpod.io/#https://github.com/fwcd/kotlin-language-server) and run `./gradlew :server:build`. It should fail.

To see the fix in action, open [this repo in gitpod](https://gitpod.io/#https://github.com/daphil19/kotlin-language-server) and run `./gradlew :server:build`. It should succeed.

This closes #254