### PR TITLE
Emit progress notifications

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -76,7 +76,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
 
         params.workDoneToken?.let {
             client.notifyProgress(ProgressParams(it, WorkDoneProgressBegin().apply {
-                title = "Adding workspace folders"
+                title = "Adding Kotlin workspace folders"
                 percentage = 0
             }))
         }

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -88,7 +88,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
 
             params.workDoneToken?.let {
                 client.notifyProgress(ProgressParams(it, WorkDoneProgressReport().apply {
-                    message = "$progressPrefix: Updating source and class path"
+                    message = "$progressPrefix: Updating source path"
                     percentage = progressPercent
                 }))
             }
@@ -96,8 +96,22 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
             val root = Paths.get(parseURI(folder.uri))
             sourceFiles.addWorkspaceRoot(root)
 
+            params.workDoneToken?.let {
+                client.notifyProgress(ProgressParams(it, WorkDoneProgressReport().apply {
+                    message = "$progressPrefix: Updating class path"
+                    percentage = progressPercent
+                }))
+            }
+
             val refreshed = classPath.addWorkspaceRoot(root)
             if (refreshed) {
+                params.workDoneToken?.let {
+                    client.notifyProgress(ProgressParams(it, WorkDoneProgressReport().apply {
+                        message = "$progressPrefix: Refreshing source path"
+                        percentage = progressPercent
+                    }))
+                }
+
                 sourcePath.refresh()
             }
         }

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -83,11 +83,13 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
 
         folders.forEachIndexed { i, folder ->
             LOG.info("Adding workspace folder {}", folder.name)
+            val progressPrefix = "[${i + 1}/${folders.size}] ${folder.name}"
+            val progressPercent = (100 * i) / folders.size
 
             params.workDoneToken?.let {
-                client.notifyProgress(ProgressParams(params.workDoneToken, WorkDoneProgressReport().apply {
-                    message = "[${i + 1}/${folders.size}] ${folder.name}"
-                    percentage = (100 * i) / folders.size
+                client.notifyProgress(ProgressParams(it, WorkDoneProgressReport().apply {
+                    message = "$progressPrefix: Updating source and class path"
+                    percentage = progressPercent
                 }))
             }
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -73,17 +73,23 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         config.completion.snippets.enabled = clientCapabilities?.textDocument?.completion?.completionItem?.snippetSupport ?: false
 
         val folders = params.workspaceFolders
-        client.notifyProgress(ProgressParams(params.workDoneToken, WorkDoneProgressBegin().apply {
-            title = "Adding workspace folders"
-            percentage = 0
-        }))
+
+        params.workDoneToken?.let {
+            client.notifyProgress(ProgressParams(it, WorkDoneProgressBegin().apply {
+                title = "Adding workspace folders"
+                percentage = 0
+            }))
+        }
 
         folders.forEachIndexed { i, folder ->
             LOG.info("Adding workspace {} to source path", params.rootUri)
-            client.notifyProgress(ProgressParams(params.workDoneToken, WorkDoneProgressReport().apply {
-                message = "[${i + 1}/${folders.size}] ${folder.name}"
-                percentage = (100 * i) / folders.size
-            }))
+
+            params.workDoneToken?.let {
+                client.notifyProgress(ProgressParams(params.workDoneToken, WorkDoneProgressReport().apply {
+                    message = "[${i + 1}/${folders.size}] ${folder.name}"
+                    percentage = (100 * i) / folders.size
+                }))
+            }
 
             val root = Paths.get(parseURI(folder.uri))
             sourceFiles.addWorkspaceRoot(root)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -82,7 +82,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         }
 
         folders.forEachIndexed { i, folder ->
-            LOG.info("Adding workspace {} to source path", params.rootUri)
+            LOG.info("Adding workspace folder {}", folder.name)
 
             params.workDoneToken?.let {
                 client.notifyProgress(ProgressParams(params.workDoneToken, WorkDoneProgressReport().apply {

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -32,7 +32,10 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
             }
         }
 
-        init.rootUri = workspaceRoot.toUri().toString()
+        init.workspaceFolders = listOf(WorkspaceFolder().apply {
+            name = workspaceRoot.fileName.toString()
+            uri = workspaceRoot.toUri().toString()
+        })
         languageServer.initialize(init)
         languageServer.connect(this)
 

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -36,8 +36,8 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
             name = workspaceRoot.fileName.toString()
             uri = workspaceRoot.toUri().toString()
         })
-        languageServer.initialize(init)
         languageServer.connect(this)
+        languageServer.initialize(init).join()
 
         return languageServer
     }


### PR DESCRIPTION
### Fixes #266 

With LSP adding support for official progress indicator, we can drop the custom `Initializing Kotlin Language Server...` status indicator in the VSCode and emit more detailed information on the server side, e.g. like this:

![image](https://user-images.githubusercontent.com/30873659/109082035-7cf57380-7703-11eb-9da7-cb9544ad4b4f.png)
