### PR TITLE
Index global descriptors and provide completions for unimported symbols

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 projectVersion=0.9.1
 kotlinVersion=1.4.30-RC-232
+exposedVersion=0.29.1
 javaVersion=11

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 projectVersion=0.9.1
-kotlinVersion=1.4.20-release-327
+kotlinVersion=1.4.30-RC-232
 javaVersion=11

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:ide-common-ij202:$kotlinVersion"
     // implementation("org.jetbrains.kotlin:kotlin-plugin-ij201:$kotlinVersion") { transitive = false }
     implementation 'org.jetbrains:fernflower:1.0'
+    implementation 'com.h2database:h2:1.4.200'
     implementation 'com.github.fwcd:ktfmt:22bd538a1c'
     implementation 'com.beust:jcommander:1.78'
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,7 +29,7 @@ repositories {
     maven { url 'https://jitpack.io' }
     // TODO: Update once https://github.com/JetBrains/Exposed/issues/1160 is resolved
     //       since Bintray will be shutting down soon
-    maven { url 'https://dl.bintray.com/kotlin/exposed/' }
+    maven { url 'https://cache-redirector.jetbrains.com/dl.bintray.com/kotlin/exposed' }
 }
 
 dependencies {
@@ -44,7 +44,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:ide-common-ij202:$kotlinVersion"
     // implementation("org.jetbrains.kotlin:kotlin-plugin-ij201:$kotlinVersion") { transitive = false }
     implementation 'org.jetbrains:fernflower:1.0'
-    implementation 'org.jetbrains.exposed:exposed:0.17.9'
+    implementation 'org.jetbrains.exposed:exposed-core:0.29.1'
     implementation 'com.h2database:h2:1.4.200'
     implementation 'com.github.fwcd:ktfmt:22bd538a1c'
     implementation 'com.beust:jcommander:1.78'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-scripting-compiler-impl:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-scripting-jvm-host-unshaded:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:ide-common-ij201:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:ide-common-ij202:$kotlinVersion"
     // implementation("org.jetbrains.kotlin:kotlin-plugin-ij201:$kotlinVersion") { transitive = false }
     implementation 'org.jetbrains:fernflower:1.0'
     implementation 'com.github.fwcd:ktfmt:22bd538a1c'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,9 @@ startScripts {
 repositories {
     maven { url uri("$projectDir/lib") }
     maven { url 'https://jitpack.io' }
+    // TODO: Update once https://github.com/JetBrains/Exposed/issues/1160 is resolved
+    //       since Bintray will be shutting down soon
+    maven { url 'https://dl.bintray.com/kotlin/exposed/' }
 }
 
 dependencies {
@@ -41,6 +44,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:ide-common-ij202:$kotlinVersion"
     // implementation("org.jetbrains.kotlin:kotlin-plugin-ij201:$kotlinVersion") { transitive = false }
     implementation 'org.jetbrains:fernflower:1.0'
+    implementation 'org.jetbrains.exposed:exposed:0.17.9'
     implementation 'com.h2database:h2:1.4.200'
     implementation 'com.github.fwcd:ktfmt:22bd538a1c'
     implementation 'com.beust:jcommander:1.78'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -44,7 +44,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:ide-common-ij202:$kotlinVersion"
     // implementation("org.jetbrains.kotlin:kotlin-plugin-ij201:$kotlinVersion") { transitive = false }
     implementation 'org.jetbrains:fernflower:1.0'
-    implementation 'org.jetbrains.exposed:exposed-core:0.29.1'
+    implementation "org.jetbrains.exposed:exposed-core:$exposedVersion"
+    implementation "org.jetbrains.exposed:exposed-dao:$exposedVersion"
+    implementation "org.jetbrains.exposed:exposed-jdbc:$exposedVersion"
     implementation 'com.h2database:h2:1.4.200'
     implementation 'com.github.fwcd:ktfmt:22bd538a1c'
     implementation 'com.beust:jcommander:1.78'

--- a/server/src/main/dist/licenseReport.html
+++ b/server/src/main/dist/licenseReport.html
@@ -17,6 +17,9 @@
       <pre>GNU LESSER GENERAL PUBLIC LICENSE 2.1
 <a href='https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html'>https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html</a></pre>
       <li>
+        <a href='#1544977522'>Joda-Time</a>
+      </li>
+      <li>
         <a href='#1544977522'>Kotlinx-coroutines-core</a>
       </li>
       <a name='1544977522' />
@@ -429,9 +432,17 @@
    limitations under the License.
 </pre>
       <li>
+        <a href='#76480'>Exposed</a>
+      </li>
+      <li>
         <a href='#76480'>Ktfmt</a>
       </li>
       <pre>No license found</pre>
+      <li>
+        <a href='#1168029172'>H2 Database Engine</a>
+      </li>
+      <pre>MPL 2.0 or EPL 1.0
+<a href='https://h2database.com/html/license.html'>https://h2database.com/html/license.html</a></pre>
       <li>
         <a href='#-989315363'>Checker Qual</a>
       </li>
@@ -545,7 +556,7 @@ SOFTWARE.
         <a href='#1288284111'>Kotlin Util Klib</a>
       </li>
       <li>
-        <a href='#1288284111'>Org.jetbrains.kotlin:ide-common-ij201</a>
+        <a href='#1288284111'>Org.jetbrains.kotlin:ide-common-ij202</a>
       </li>
       <a name='1288284111' />
       <pre>                                 Apache License
@@ -758,7 +769,10 @@ SOFTWARE.
       <li>
         <a href='#-687391964'>Animal Sniffer Annotations</a>
       </li>
-      <pre>MIT license
+      <li>
+        <a href='#-687391964'>SLF4J API Module</a>
+      </li>
+      <pre>MIT License
 <a href='http://www.opensource.org/licenses/mit-license.php'>http://www.opensource.org/licenses/mit-license.php</a></pre>
       <li>
         <a href='#79718298'>LSP4J</a>

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -23,6 +23,11 @@ public data class CompilerConfiguration(
     val jvm: JVMConfiguration = JVMConfiguration()
 )
 
+public data class IndexingConfiguration(
+    /** Whether an index of global symbols should be built in the background. */
+    var enabled: Boolean = true
+)
+
 public data class ExternalSourcesConfiguration(
     /** Whether kls-URIs should be sent to the client to describe classes in JARs. */
     var useKlsScheme: Boolean = false,
@@ -34,5 +39,6 @@ public data class Configuration(
     val compiler: CompilerConfiguration = CompilerConfiguration(),
     val completion: CompletionConfiguration = CompletionConfiguration(),
     val linting: LintingConfiguration = LintingConfiguration(),
+    var indexing: IndexingConfiguration = IndexingConfiguration(),
     val externalSources: ExternalSourcesConfiguration = ExternalSourcesConfiguration()
 )

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -45,8 +45,6 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         this.client = client
         connectLoggingBackend()
 
-        progressFactory = LanguageClientProgress.Factory(client)
-
         workspaces.connect(client)
         textDocuments.connect(client)
 
@@ -81,6 +79,10 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
 
         val clientCapabilities = params.capabilities
         config.completion.snippets.enabled = clientCapabilities?.textDocument?.completion?.completionItem?.snippetSupport ?: false
+
+        if (clientCapabilities.window.workDoneProgress) {
+            progressFactory = LanguageClientProgress.Factory(client)
+        }
 
         val folders = params.workspaceFolders
         val progress = params.workDoneToken?.let { LanguageClientProgress("Workspace folders", it, client) }

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -33,9 +33,13 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
     private val protocolExtensions = KotlinProtocolExtensionService(uriContentProvider)
 
     private lateinit var client: LanguageClient
-    private lateinit var progressFactory: Progress.Factory
 
     private val async = AsyncExecutor()
+    private var progressFactory: Progress.Factory = Progress.Factory.None
+        set(factory: Progress.Factory) {
+            field = factory
+            sourcePath.progressFactory = factory
+        }
 
     override fun connect(client: LanguageClient) {
         this.client = client

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -80,7 +80,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         val clientCapabilities = params.capabilities
         config.completion.snippets.enabled = clientCapabilities?.textDocument?.completion?.completionItem?.snippetSupport ?: false
 
-        if (clientCapabilities.window.workDoneProgress) {
+        if (clientCapabilities?.window?.workDoneProgress ?: false) {
             progressFactory = LanguageClientProgress.Factory(client)
         }
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -20,12 +20,12 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletableFuture.completedFuture
 
 class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
-    private val config = Configuration()
+    val config = Configuration()
     val classPath = CompilerClassPath(config.compiler)
 
     private val tempDirectory = TemporaryDirectory()
     private val uriContentProvider = URIContentProvider(JarClassContentProvider(config.externalSources, classPath, tempDirectory))
-    val sourcePath = SourcePath(classPath, uriContentProvider)
+    val sourcePath = SourcePath(classPath, uriContentProvider, config.indexing)
     val sourceFiles = SourceFiles(sourcePath, uriContentProvider)
 
     private val textDocuments = KotlinTextDocumentService(sourceFiles, sourcePath, config, tempDirectory, uriContentProvider)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -156,7 +156,7 @@ class KotlinTextDocumentService(
             LOG.info("Completing at {}", describePosition(position))
 
             val (file, cursor) = recover(position, Recompile.NEVER) // TODO: Investigate when to recompile
-            val completions = completions(file, cursor, config.completion)
+            val completions = completions(file, cursor, sp.index, config.completion)
             LOG.info("Found {} items", completions.items.size)
 
             Either.forRight<List<CompletionItem>, CompletionList>(completions)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -128,7 +128,6 @@ class KotlinWorkspaceService(
                 val indexing = config.indexing
                 get("enabled")?.asBoolean?.let {
                     indexing.enabled = it
-                    sp.indexEnabled = it
                 }
             }
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -123,6 +123,15 @@ class KotlinWorkspaceService(
                 }
             }
 
+            // Update indexing options
+            get("indexing")?.asJsonObject?.apply {
+                val indexing = config.indexing
+                get("enabled")?.asBoolean?.let {
+                    indexing.enabled = it
+                    sp.indexEnabled = it
+                }
+            }
+
             // Update options about external sources e.g. JAR files, decompilers, etc
             get("externalSources")?.asJsonObject?.apply {
                 val externalSources = config.externalSources

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -7,6 +7,7 @@ import org.javacs.kt.util.filePath
 import org.javacs.kt.util.describeURI
 import org.javacs.kt.index.SymbolIndex
 import org.javacs.kt.progress.Progress
+import org.javacs.kt.IndexingConfiguration
 import com.intellij.lang.Language
 import com.intellij.psi.PsiFile
 import com.intellij.openapi.fileTypes.FileType
@@ -25,14 +26,15 @@ import java.util.concurrent.locks.ReentrantLock
 
 class SourcePath(
     private val cp: CompilerClassPath,
-    private val contentProvider: URIContentProvider
+    private val contentProvider: URIContentProvider,
+    private val indexingConfig: IndexingConfiguration
 ) {
     private val files = mutableMapOf<URI, SourceFile>()
     private val parseDataWriteLock = ReentrantLock()
     private val indexAsync = AsyncExecutor()
 
     val index = SymbolIndex()
-    var indexEnabled = true
+    var indexEnabled: Boolean by indexingConfig::enabled
     var beforeCompileCallback: () -> Unit = {}
 
     var progressFactory: Progress.Factory = Progress.Factory.None

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -31,6 +31,7 @@ class SourcePath(
     private val indexAsync = AsyncExecutor()
 
     val index = SymbolIndex()
+    var indexEnabled = true
     var beforeCompileCallback: () -> Unit = {}
 
     private inner class SourceFile(
@@ -201,7 +202,7 @@ class SourcePath(
             }
 
             // Only index normal files, not build files
-            if (kind == CompilationKind.DEFAULT) {
+            if (indexEnabled && kind == CompilationKind.DEFAULT) {
                 updateIndexAsync(container)
             }
 
@@ -222,8 +223,8 @@ class SourcePath(
      * Updates the symbol index asynchronously.
      */
     private fun updateIndexAsync(container: ComponentProvider) = indexAsync.execute {
-        // val module = container.getService(ModuleDescriptor::class.java)
-        // index.update(module)
+        val module = container.getService(ModuleDescriptor::class.java)
+        index.update(module)
     }
 
     /**

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -200,7 +200,10 @@ class SourcePath(
                 }
             }
 
-            updateIndexAsync(container)
+            // Only index normal files, not build files
+            if (kind == CompilationKind.DEFAULT) {
+                updateIndexAsync(container)
+            }
 
             return context
         }
@@ -219,8 +222,8 @@ class SourcePath(
      * Updates the symbol index asynchronously.
      */
     private fun updateIndexAsync(container: ComponentProvider) = indexAsync.execute {
-        val module = container.getService(ModuleDescriptor::class.java)
-        index.update(module)
+        // val module = container.getService(ModuleDescriptor::class.java)
+        // index.update(module)
     }
 
     /**

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -5,6 +5,7 @@ import org.javacs.kt.util.AsyncExecutor
 import org.javacs.kt.util.fileExtension
 import org.javacs.kt.util.filePath
 import org.javacs.kt.util.describeURI
+import org.javacs.kt.index.SymbolIndex
 import com.intellij.lang.Language
 import com.intellij.psi.PsiFile
 import com.intellij.openapi.fileTypes.FileType

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -90,6 +90,8 @@ class SourcePath(
                 compiledContainer = container
                 compiledFile = parsed
             }
+
+            updateIndexAsync(container)
         }
 
         private fun doCompileIfChanged() {
@@ -195,11 +197,7 @@ class SourcePath(
                 }
             }
 
-            // Update symbol index asynchronously
-            val module = container.getService(ModuleDescriptor::class.java)
-            indexAsync.execute {
-                index.update(module)
-            }
+            updateIndexAsync(container)
 
             return context
         }
@@ -212,6 +210,14 @@ class SourcePath(
         val combined = listOf(buildScriptsContext, sourcesContext).filterNotNull() + same.map { it.compiledContext!! }
 
         return CompositeBindingContext.create(combined)
+    }
+
+    /**
+     * Updates the symbol index asynchronously.
+     */
+    private fun updateIndexAsync(container: ComponentProvider) = indexAsync.execute {
+        val module = container.getService(ModuleDescriptor::class.java)
+        index.update(module)
     }
 
     /**

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -6,6 +6,7 @@ import org.javacs.kt.util.fileExtension
 import org.javacs.kt.util.filePath
 import org.javacs.kt.util.describeURI
 import org.javacs.kt.index.SymbolIndex
+import org.javacs.kt.progress.Progress
 import com.intellij.lang.Language
 import com.intellij.psi.PsiFile
 import com.intellij.openapi.fileTypes.FileType
@@ -33,6 +34,12 @@ class SourcePath(
     val index = SymbolIndex()
     var indexEnabled = true
     var beforeCompileCallback: () -> Unit = {}
+
+    var progressFactory: Progress.Factory = Progress.Factory.None
+        set(factory: Progress.Factory) {
+            field = factory
+            index.progressFactory = factory
+        }
 
     private inner class SourceFile(
         val uri: URI,

--- a/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourcePath.kt
@@ -7,6 +7,8 @@ import org.javacs.kt.util.filePath
 import org.javacs.kt.util.describeURI
 import com.intellij.lang.Language
 import com.intellij.psi.PsiFile
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.LanguageFileType
 import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.container.getService
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -41,7 +43,7 @@ class SourcePath(
         val language: Language? = null,
         val isTemporary: Boolean = false // A temporary source file will not be returned by .all()
     ) {
-        val extension: String? = uri.fileExtension ?: language?.associatedFileType?.defaultExtension
+        val extension: String? = uri.fileExtension ?: "kt" // TODO: Use language?.associatedFileType?.defaultExtension again
         val isScript: Boolean = extension == "kts"
         val kind: CompilationKind =
             if (path?.fileName?.toString()?.endsWith(".gradle.kts") ?: false) CompilationKind.BUILD_SCRIPT

--- a/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
@@ -13,7 +13,7 @@ import org.javacs.kt.compiler.Compiler
 class SymbolIndex {
     val globalDescriptors: MutableSet<DeclarationDescriptor> = mutableSetOf()
 
-    private fun update(module: ModuleDescriptor) {
+    fun update(module: ModuleDescriptor) {
         val started = System.currentTimeMillis()
         LOG.info("Updating symbol index...")
 

--- a/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
@@ -26,7 +26,7 @@ class SymbolIndex {
         }
 
         val finished = System.currentTimeMillis()
-        LOG.info("Updated symbol index in ${finished - started} ms!")
+        LOG.info("Updated symbol index in ${finished - started} ms! (${globalDescriptors.size} symbol(s))")
     }
 
     fun <T> withGlobalDescriptors(action: (Set<DeclarationDescriptor>) -> T): T = lock.withLock { action(globalDescriptors) }

--- a/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
@@ -1,0 +1,14 @@
+package org.javacs.kt
+
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.name.FqName
+
+/**
+ * A global view of all available symbols across all packages.
+ */
+class SymbolIndex(private val module: ModuleDescriptor) {
+    private fun allPackages(pkgName: FqName = FqName.ROOT): Collection<FqName> = module
+        .getSubPackagesOf(pkgName) { true }
+        .flatMap(::allPackages)
+}

--- a/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
@@ -2,13 +2,32 @@ package org.javacs.kt
 
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.name.FqName
+import org.javacs.kt.compiler.Compiler
 
 /**
  * A global view of all available symbols across all packages.
  */
-class SymbolIndex(private val module: ModuleDescriptor) {
-    private fun allPackages(pkgName: FqName = FqName.ROOT): Collection<FqName> = module
+class SymbolIndex {
+    val globalDescriptors: MutableSet<DeclarationDescriptor> = mutableSetOf()
+
+    private fun update(module: ModuleDescriptor) {
+        val started = System.currentTimeMillis()
+        LOG.info("Updating symbol index...")
+
+        globalDescriptors += allDescriptors(module)
+
+        val finished = System.currentTimeMillis()
+        LOG.info("Updated symbol index in ${finished - started} ms!")
+    }
+
+    private fun allDescriptors(module: ModuleDescriptor): Collection<DeclarationDescriptor> = allPackages(module)
+        .map(module::getPackage)
+        .flatMap { it.memberScope.getContributedDescriptors(DescriptorKindFilter.ALL, MemberScope.ALL_NAME_FILTER) }
+
+    private fun allPackages(module: ModuleDescriptor, pkgName: FqName = FqName.ROOT): Collection<FqName> = module
         .getSubPackagesOf(pkgName) { true }
-        .flatMap(::allPackages)
+        .flatMap { allPackages(module, it) }
 }

--- a/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
@@ -13,7 +13,7 @@ import kotlin.concurrent.withLock
  * A global view of all available symbols across all packages.
  */
 class SymbolIndex {
-    val globalDescriptors: MutableSet<DeclarationDescriptor> = mutableSetOf()
+    private val globalDescriptors: MutableSet<DeclarationDescriptor> = mutableSetOf()
     private val lock = ReentrantLock()
 
     fun update(module: ModuleDescriptor) {
@@ -28,6 +28,8 @@ class SymbolIndex {
         val finished = System.currentTimeMillis()
         LOG.info("Updated symbol index in ${finished - started} ms!")
     }
+
+    fun <T> withGlobalDescriptors(action: (Set<DeclarationDescriptor>) -> T): T = lock.withLock { action(globalDescriptors) }
 
     private fun allDescriptors(module: ModuleDescriptor): Collection<DeclarationDescriptor> = allPackages(module)
         .map(module::getPackage)

--- a/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SymbolIndex.kt
@@ -36,6 +36,6 @@ class SymbolIndex {
         .flatMap { it.memberScope.getContributedDescriptors(DescriptorKindFilter.ALL, MemberScope.ALL_NAME_FILTER) }
 
     private fun allPackages(module: ModuleDescriptor, pkgName: FqName = FqName.ROOT): Collection<FqName> = module
-        .getSubPackagesOf(pkgName) { true }
+        .getSubPackagesOf(pkgName) { it.toString() != "META-INF" }
         .flatMap { allPackages(module, it) }
 }

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -158,7 +158,7 @@ data class ElementCompletionItems(val items: Sequence<CompletionItem>, val isExh
 
 /** Finds completions based on the element around the user's cursor. */
 private fun elementCompletionItems(file: CompiledFile, cursor: Int, config: CompletionConfiguration, partial: String): ElementCompletionItems {
-    val surroundingElement = completableElement(file, cursor) ?: return ElementCompletionItems(emptySequence(), isExhaustive = false)
+    val surroundingElement = completableElement(file, cursor) ?: return ElementCompletionItems(emptySequence(), isExhaustive = true)
     val isExhaustive = surroundingElement !is KtNameReferenceExpression && surroundingElement !is KtTypeElement
     val completions = elementCompletions(file, cursor, surroundingElement)
 

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -7,8 +7,8 @@ import org.eclipse.lsp4j.CompletionItemTag
 import org.eclipse.lsp4j.CompletionList
 import org.javacs.kt.CompiledFile
 import org.javacs.kt.LOG
-import org.javacs.kt.SymbolIndex
 import org.javacs.kt.CompletionConfiguration
+import org.javacs.kt.index.SymbolIndex
 import org.javacs.kt.util.containsCharactersInOrder
 import org.javacs.kt.util.findParent
 import org.javacs.kt.util.noResult

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -81,6 +81,8 @@ fun completions(file: CompiledFile, cursor: Int, index: SymbolIndex, config: Com
 /** Finds completions in the global symbol index, for potentially unimported symbols. */
 private fun indexCompletionItems(parsedFile: KtFile, index: SymbolIndex, partial: String): Sequence<CompletionItem> = index
     .query(partial, limit = MAX_COMPLETION_ITEMS)
+    .asSequence()
+    .filter { it.kind != Symbol.Kind.MODULE } // Ignore global module/package name completions for now, since they cannot be 'imported'
     .map { CompletionItem().apply {
         label = it.fqName.shortName().toString()
         kind = when (it.kind) {
@@ -98,7 +100,6 @@ private fun indexCompletionItems(parsedFile: KtFile, index: SymbolIndex, partial
         val pos = findImportInsertionPosition(parsedFile, it.fqName)
         additionalTextEdits = listOf(TextEdit(Range(pos, pos), "\nimport ${it.fqName}")) // TODO: CRLF?
     } }
-    .asSequence()
 
 /** Finds a good insertion position for a new import of the given fully-qualified name. */
 private fun findImportInsertionPosition(parsedFile: KtFile, fqName: FqName): Position =

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -101,6 +101,7 @@ private fun indexCompletionItems(parsedFile: KtFile, index: SymbolIndex, partial
                 Symbol.Kind.ENUM_MEMBER -> CompletionItemKind.EnumMember
                 Symbol.Kind.CONSTRUCTOR -> CompletionItemKind.Constructor
                 Symbol.Kind.FIELD -> CompletionItemKind.Field
+                Symbol.Kind.UNKNOWN -> CompletionItemKind.Text
             }
             detail = "(import from ${it.fqName.parent()})"
             val pos = findImportInsertionPosition(parsedFile, it.fqName)

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -89,6 +89,12 @@ private fun indexCompletionItems(parsedFile: KtFile, index: SymbolIndex, partial
         .asSequence()
         .filter { it.kind != Symbol.Kind.MODULE } // Ignore global module/package name completions for now, since they cannot be 'imported'
         .filter { it.fqName.shortName() !in importedNames }
+        .filter {
+            // TODO: Visibility checker should be less liberal
+               it.visibility == Symbol.Visibility.PUBLIC
+            || it.visibility == Symbol.Visibility.PROTECTED
+            || it.visibility == Symbol.Visibility.INTERNAL
+        }
         .map { CompletionItem().apply {
             label = it.fqName.shortName().toString()
             kind = when (it.kind) {

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.types.typeUtil.replaceArgumentsWithStarProjections
 import org.jetbrains.kotlin.types.checker.KotlinTypeChecker
 import java.util.concurrent.TimeUnit
 
-// The maxmimum number of completion items
+// The maximum number of completion items
 private const val MAX_COMPLETION_ITEMS = 75
 
 // The minimum length after which completion lists are sorted

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -97,7 +97,7 @@ private fun indexCompletionItems(file: CompiledFile, cursor: Int, receiver: KtEx
     val receiverTypeFqName = receiverType?.constructor?.declarationDescriptor?.fqNameSafe
 
     return index
-        .query(partial, limit = MAX_COMPLETION_ITEMS)
+        .query(partial, receiverTypeFqName, limit = MAX_COMPLETION_ITEMS)
         .asSequence()
         .filter { it.kind != Symbol.Kind.MODULE } // Ignore global module/package name completions for now, since they cannot be 'imported'
         .filter { it.fqName.shortName() !in importedNames && it.fqName.parent() !in wildcardPackages }
@@ -107,7 +107,6 @@ private fun indexCompletionItems(file: CompiledFile, cursor: Int, receiver: KtEx
             || it.visibility == Symbol.Visibility.PROTECTED
             || it.visibility == Symbol.Visibility.INTERNAL
         }
-        .filter { receiverTypeFqName == it.extensionReceiverType } // if both are null, it's not an extension
         .map { CompletionItem().apply {
             label = it.fqName.shortName().toString()
             kind = when (it.kind) {

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -5,6 +5,9 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionItemTag
 import org.eclipse.lsp4j.CompletionList
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.Position
 import org.javacs.kt.CompiledFile
 import org.javacs.kt.LOG
 import org.javacs.kt.CompletionConfiguration
@@ -89,6 +92,9 @@ private fun indexCompletionItems(index: SymbolIndex, partial: String): Sequence<
             Symbol.Kind.CONSTRUCTOR -> CompletionItemKind.Constructor
             Symbol.Kind.FIELD -> CompletionItemKind.Field
         }
+        detail = "(import from ${it.fqName.parent()})"
+        // TODO: Use actual range
+        additionalTextEdits = listOf(TextEdit(Range(Position(0, 0), Position(0, 0)), "import ${it.fqName}\n"))
     } }
     .asSequence()
 

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -82,11 +82,7 @@ private fun keywordCompletionItems(partial: String): Sequence<CompletionItem> =
 /** Finds completions based on the element around the user's cursor. */
 private fun elementCompletionItems(file: CompiledFile, cursor: Int, index: SymbolIndex, config: CompletionConfiguration, partial: String): Sequence<CompletionItem> {
     val surroundingElement = completableElement(file, cursor) ?: return emptySequence()
-    var completions = elementCompletions(file, cursor, surroundingElement)
-
-    index.withGlobalDescriptors {
-        completions += it // TODO: Filter non-imported (i.e. the elementCompletions already found) and auto-import these when selected by the user
-    }
+    val completions = elementCompletions(file, cursor, surroundingElement) + index.globalDescriptors.values // TODO: Filter non-imported (i.e. the elementCompletions already found) and auto-import these when selected by the user
 
     val matchesName = completions.filter { containsCharactersInOrder(name(it), partial, caseSensitive = false) }
     val sorted = matchesName.takeIf { partial.length >= MIN_SORT_LENGTH }?.sortedBy { stringDistance(name(it), partial) }

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -103,7 +103,8 @@ private fun indexCompletionItems(parsedFile: KtFile, index: SymbolIndex, partial
             }
             detail = "(import from ${it.fqName.parent()})"
             val pos = findImportInsertionPosition(parsedFile, it.fqName)
-            additionalTextEdits = listOf(TextEdit(Range(pos, pos), "\nimport ${it.fqName}")) // TODO: CRLF?
+            val prefix = if (importedNames.isEmpty()) "\n\n" else "\n"
+            additionalTextEdits = listOf(TextEdit(Range(pos, pos), "${prefix}import ${it.fqName}")) // TODO: CRLF?
         } }
 }
 

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -64,10 +64,11 @@ fun completions(file: CompiledFile, cursor: Int, index: SymbolIndex, config: Com
     LOG.debug("Looking for completions that match '{}'", partial)
 
     val (elementItems, isExhaustive) = elementCompletionItems(file, cursor, config, partial)
-    val elementItemList = elementItems.take(MAX_COMPLETION_ITEMS).toList()
+    val elementItemList = elementItems.toList()
+    val elementItemLabels = elementItemList.mapNotNull { it.label }.toSet()
     val items = (
         elementItemList.asSequence()
-        + (if (!isExhaustive) indexCompletionItems(file.parse, index, partial) else emptySequence())
+        + (if (!isExhaustive) indexCompletionItems(file.parse, index, partial).filter { it.label !in elementItemLabels } else emptySequence())
         + (if (elementItemList.isEmpty()) keywordCompletionItems(partial) else emptySequence())
     )
     val itemList = items

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -78,13 +78,13 @@ fun completions(file: CompiledFile, cursor: Int, index: SymbolIndex, config: Com
 
 /** Finds completions in the global symbol index, for potentially unimported symbols. */
 private fun indexCompletionItems(parsedFile: KtFile, index: SymbolIndex, partial: String): Sequence<CompletionItem> {
-    val importedFqNames = parsedFile.importDirectives.mapNotNull { it.importedFqName }.toSet()
+    val importedNames = parsedFile.importDirectives.mapNotNull { it.importedFqName?.shortName() }.toSet()
 
     return index
         .query(partial, limit = MAX_COMPLETION_ITEMS)
         .asSequence()
         .filter { it.kind != Symbol.Kind.MODULE } // Ignore global module/package name completions for now, since they cannot be 'imported'
-        .filter { it.fqName !in importedFqNames }
+        .filter { it.fqName.shortName() !in importedNames }
         .map { CompletionItem().apply {
             label = it.fqName.shortName().toString()
             kind = when (it.kind) {

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -65,8 +65,11 @@ fun completions(file: CompiledFile, cursor: Int, index: SymbolIndex, config: Com
 
     val (elementItems, isExhaustive) = elementCompletionItems(file, cursor, config, partial)
     val elementItemList = elementItems.take(MAX_COMPLETION_ITEMS).toList()
-    val items = (elementItemList.asSequence() + if (isExhaustive) emptySequence() else indexCompletionItems(file.parse, index, partial))
-        .ifEmpty { keywordCompletionItems(partial) }
+    val items = (
+        elementItemList.asSequence()
+        + (if (!isExhaustive) indexCompletionItems(file.parse, index, partial) else emptySequence())
+        + (if (elementItemList.isEmpty()) keywordCompletionItems(partial) else emptySequence())
+    )
     val itemList = items
         .take(MAX_COMPLETION_ITEMS)
         .toList()

--- a/server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolExtensionReceiverType.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolExtensionReceiverType.kt
@@ -1,0 +1,14 @@
+package org.javacs.kt.index
+
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.descriptors.impl.DeclarationDescriptorVisitorEmptyBodies
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+object ExtractSymbolExtensionReceiverType : DeclarationDescriptorVisitorEmptyBodies<FqName?, Unit>() {
+    private fun convert(desc: ReceiverParameterDescriptor): FqName? = desc.value.type.constructor.declarationDescriptor?.fqNameSafe
+
+    override fun visitFunctionDescriptor(desc: FunctionDescriptor, nothing: Unit?) = desc.extensionReceiverParameter?.let(this::convert)
+
+    override fun visitVariableDescriptor(desc: VariableDescriptor, nothing: Unit?) = desc.extensionReceiverParameter?.let(this::convert)
+}

--- a/server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolKind.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolKind.kt
@@ -1,0 +1,40 @@
+package org.javacs.kt.index
+
+import org.jetbrains.kotlin.descriptors.*
+
+object ExtractSymbolKind : DeclarationDescriptorVisitor<Symbol.Kind, Unit> {
+    override fun visitPropertySetterDescriptor(desc: PropertySetterDescriptor, nothing: Unit?) = Symbol.Kind.FIELD
+
+    override fun visitConstructorDescriptor(desc: ConstructorDescriptor, nothing: Unit?) = Symbol.Kind.CONSTRUCTOR
+
+    override fun visitReceiverParameterDescriptor(desc: ReceiverParameterDescriptor, nothing: Unit?) = Symbol.Kind.VARIABLE
+
+    override fun visitPackageViewDescriptor(desc: PackageViewDescriptor, nothing: Unit?) = Symbol.Kind.MODULE
+
+    override fun visitFunctionDescriptor(desc: FunctionDescriptor, nothing: Unit?) = Symbol.Kind.FUNCTION
+
+    override fun visitModuleDeclaration(desc: ModuleDescriptor, nothing: Unit?) = Symbol.Kind.MODULE
+
+    override fun visitClassDescriptor(desc: ClassDescriptor, nothing: Unit?): Symbol.Kind = when (desc.kind) {
+        ClassKind.INTERFACE -> Symbol.Kind.INTERFACE
+        ClassKind.ENUM_CLASS -> Symbol.Kind.ENUM
+        ClassKind.ENUM_ENTRY -> Symbol.Kind.ENUM_MEMBER
+        else -> Symbol.Kind.CLASS
+    }
+
+    override fun visitPackageFragmentDescriptor(desc: PackageFragmentDescriptor, nothing: Unit?) = Symbol.Kind.MODULE
+
+    override fun visitValueParameterDescriptor(desc: ValueParameterDescriptor, nothing: Unit?) = Symbol.Kind.VARIABLE
+
+    override fun visitTypeParameterDescriptor(desc: TypeParameterDescriptor, nothing: Unit?) = Symbol.Kind.VARIABLE
+
+    override fun visitScriptDescriptor(desc: ScriptDescriptor, nothing: Unit?) = Symbol.Kind.MODULE
+
+    override fun visitTypeAliasDescriptor(desc: TypeAliasDescriptor, nothing: Unit?) = Symbol.Kind.VARIABLE
+
+    override fun visitPropertyGetterDescriptor(desc: PropertyGetterDescriptor, nothing: Unit?) = Symbol.Kind.VARIABLE
+
+    override fun visitVariableDescriptor(desc: VariableDescriptor, nothing: Unit?) = Symbol.Kind.VARIABLE
+
+    override fun visitPropertyDescriptor(desc: PropertyDescriptor, nothing: Unit?) = Symbol.Kind.VARIABLE
+}

--- a/server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolVisibility.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/ExtractSymbolVisibility.kt
@@ -1,0 +1,44 @@
+package org.javacs.kt.index
+
+import org.jetbrains.kotlin.descriptors.*
+
+object ExtractSymbolVisibility : DeclarationDescriptorVisitor<Symbol.Visibility, Unit> {
+    private fun convert(visibility: DescriptorVisibility): Symbol.Visibility = when (visibility.delegate) {
+        Visibilities.PrivateToThis -> Symbol.Visibility.PRIAVTE_TO_THIS
+        Visibilities.Private -> Symbol.Visibility.PRIVATE
+        Visibilities.Internal -> Symbol.Visibility.INTERNAL
+        Visibilities.Protected -> Symbol.Visibility.PROTECTED
+        Visibilities.Public -> Symbol.Visibility.PUBLIC
+        else -> Symbol.Visibility.UNKNOWN
+    }
+
+    override fun visitPropertySetterDescriptor(desc: PropertySetterDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitConstructorDescriptor(desc: ConstructorDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitReceiverParameterDescriptor(desc: ReceiverParameterDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitPackageViewDescriptor(desc: PackageViewDescriptor, nothing: Unit?) = Symbol.Visibility.PUBLIC
+
+    override fun visitFunctionDescriptor(desc: FunctionDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitModuleDeclaration(desc: ModuleDescriptor, nothing: Unit?) = Symbol.Visibility.PUBLIC
+
+    override fun visitClassDescriptor(desc: ClassDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitPackageFragmentDescriptor(desc: PackageFragmentDescriptor, nothing: Unit?) = Symbol.Visibility.PUBLIC
+
+    override fun visitValueParameterDescriptor(desc: ValueParameterDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitTypeParameterDescriptor(desc: TypeParameterDescriptor, nothing: Unit?) = Symbol.Visibility.PUBLIC
+
+    override fun visitScriptDescriptor(desc: ScriptDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitTypeAliasDescriptor(desc: TypeAliasDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitPropertyGetterDescriptor(desc: PropertyGetterDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitVariableDescriptor(desc: VariableDescriptor, nothing: Unit?) = convert(desc.visibility)
+
+    override fun visitPropertyDescriptor(desc: PropertyDescriptor, nothing: Unit?) = convert(desc.visibility)
+}

--- a/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
@@ -1,0 +1,16 @@
+package org.javacs.kt.index
+
+import org.jetbrains.kotlin.name.FqName
+
+data class Symbol(
+    // TODO: Store location (e.g. using a URI)
+    private val fqName: FqName,
+    private val kind: Kind
+) {
+    enum class Kind {
+        CLASS,
+        INTERFACE,
+        FUNCTION,
+        VARIABLE
+    }
+}

--- a/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.name.FqName
 
 data class Symbol(
     // TODO: Store location (e.g. using a URI)
-    private val fqName: FqName,
-    private val kind: Kind
+    val fqName: FqName,
+    val kind: Kind
 ) {
     enum class Kind(val rawValue: Int) {
         CLASS(0),

--- a/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
@@ -6,7 +6,8 @@ data class Symbol(
     // TODO: Store location (e.g. using a URI)
     val fqName: FqName,
     val kind: Kind,
-    val visibility: Visibility
+    val visibility: Visibility,
+    val extensionReceiverType: FqName?
 ) {
     enum class Kind(val rawValue: Int) {
         CLASS(0),

--- a/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
@@ -5,7 +5,8 @@ import org.jetbrains.kotlin.name.FqName
 data class Symbol(
     // TODO: Store location (e.g. using a URI)
     val fqName: FqName,
-    val kind: Kind
+    val kind: Kind,
+    val visibility: Visibility
 ) {
     enum class Kind(val rawValue: Int) {
         CLASS(0),
@@ -16,10 +17,24 @@ data class Symbol(
         ENUM(5),
         ENUM_MEMBER(6),
         CONSTRUCTOR(7),
-        FIELD(8);
+        FIELD(8),
+        UNKNOWN(9);
 
         companion object {
-            fun fromRaw(rawValue: Int) = Kind.values().first { it.rawValue == rawValue }
+            fun fromRaw(rawValue: Int) = Kind.values().firstOrNull { it.rawValue == rawValue } ?: Kind.UNKNOWN
+        }
+    }
+
+    enum class Visibility(val rawValue: Int) {
+        PRIAVTE_TO_THIS(0),
+        PRIVATE(1),
+        INTERNAL(2),
+        PROTECTED(3),
+        PUBLIC(4),
+        UNKNOWN(5);
+
+        companion object {
+            fun fromRaw(rawValue: Int) = Visibility.values().firstOrNull { it.rawValue == rawValue } ?: Visibility.UNKNOWN
         }
     }
 }

--- a/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/Symbol.kt
@@ -7,10 +7,19 @@ data class Symbol(
     private val fqName: FqName,
     private val kind: Kind
 ) {
-    enum class Kind {
-        CLASS,
-        INTERFACE,
-        FUNCTION,
-        VARIABLE
+    enum class Kind(val rawValue: Int) {
+        CLASS(0),
+        INTERFACE(1),
+        FUNCTION(2),
+        VARIABLE(3),
+        MODULE(4),
+        ENUM(5),
+        ENUM_MEMBER(6),
+        CONSTRUCTOR(7),
+        FIELD(8);
+
+        companion object {
+            fun fromRaw(rawValue: Int) = Kind.values().first { it.rawValue == rawValue }
+        }
     }
 }

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -22,7 +22,7 @@ private object Symbols : Table() {
  * A global view of all available symbols across all packages.
  */
 class SymbolIndex {
-    private val db = Database.connect("jdbc:h2:mem:symbolindex", "org.h2.Driver")
+    private val db = Database.connect("jdbc:h2:mem:symbolindex;DB_CLOSE_DELAY=-1", "org.h2.Driver")
 
     init {
         transaction(db) {

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -13,7 +13,7 @@ import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.insert
 
 private object Symbols : Table() {
-    val fqName = varchar("fqname", length = 255).autoIncrement().primaryKey()
+    val fqName = varchar("fqname", length = 255).primaryKey()
     val shortName = varchar("shortname", length = 127)
     val kind = integer("kind")
 }

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -35,11 +35,16 @@ class SymbolIndex {
         LOG.info("Updating symbol index...")
 
         try {
+            val descriptors = allDescriptors(module)
+
+            // TODO: Incremental updates
             transaction(db) {
-                for (descriptor in allDescriptors(module)) {
+                Symbols.deleteAll()
+
+                for (descriptor in descriptors) {
                     val fqn = descriptor.fqNameSafe
 
-                    Symbols.insert {
+                    Symbols.insertIgnore {
                         it[fqName] = fqn.toString()
                         it[shortName] = fqn.shortName().toString()
                         it[kind] = descriptor.accept(ExtractSymbolKind, Unit).rawValue

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -26,7 +26,6 @@ private object Symbols : Table() {
  */
 class SymbolIndex {
     private val db = Database.connect("jdbc:h2:mem:symbolindex;DB_CLOSE_DELAY=-1", "org.h2.Driver")
-    private var initialized = false
 
     var progressFactory: Progress.Factory = Progress.Factory.None
 
@@ -36,11 +35,8 @@ class SymbolIndex {
         }
     }
 
-    fun update(module: ModuleDescriptor) {
-        // TODO: Remove this once a proper debounce mechanism (and ideally incremental updates) are in place.
-        if (initialized) return
-        initialized = true
-
+    /** Rebuilds the entire index. May take a while. */
+    fun refresh(module: ModuleDescriptor) {
         val started = System.currentTimeMillis()
         LOG.info("Updating symbol index...")
 

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -22,12 +22,17 @@ class SymbolIndex {
         val started = System.currentTimeMillis()
         LOG.info("Updating symbol index...")
 
-        for (descriptor in allDescriptors(module)) {
-            globalDescriptors[descriptor.fqNameSafe] = descriptor
-        }
+        try {
+            for (descriptor in allDescriptors(module)) {
+                globalDescriptors[descriptor.fqNameSafe] = descriptor
+            }
 
-        val finished = System.currentTimeMillis()
-        LOG.info("Updated symbol index in ${finished - started} ms! (${globalDescriptors.size} symbol(s))")
+            val finished = System.currentTimeMillis()
+            LOG.info("Updated symbol index in ${finished - started} ms! (${globalDescriptors.size} symbol(s))")
+        } catch (e: Exception) {
+            LOG.error("Error while updating symbol index")
+            LOG.printStackTrace(e)
+        }
     }
 
     private fun allDescriptors(module: ModuleDescriptor): Collection<DeclarationDescriptor> = allPackages(module)

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi2ir.intermediate.extensionReceiverType
 import org.javacs.kt.LOG
 import org.javacs.kt.progress.Progress
 import org.jetbrains.exposed.sql.Database
@@ -19,6 +20,7 @@ private object Symbols : Table() {
     val shortName = varchar("shortname", length = 80)
     val kind = integer("kind")
     val visibility = integer("visibility")
+    val extensionReceiverType = varchar("extensionreceivertype", length = 255).nullable()
 }
 
 /**
@@ -62,6 +64,7 @@ class SymbolIndex {
                                 it[shortName] = fqn.shortName().toString()
                                 it[kind] = descriptor.accept(ExtractSymbolKind, Unit).rawValue
                                 it[visibility] = descriptor.accept(ExtractSymbolVisibility, Unit).rawValue
+                                it[extensionReceiverType] = descriptor.accept(ExtractSymbolExtensionReceiverType, Unit)?.toString()
                             }
                         }
                     }
@@ -86,7 +89,8 @@ class SymbolIndex {
             .map { Symbol(
                 fqName = FqName(it[Symbols.fqName]),
                 kind = Symbol.Kind.fromRaw(it[Symbols.kind]),
-                visibility = Symbol.Visibility.fromRaw(it[Symbols.visibility])
+                visibility = Symbol.Visibility.fromRaw(it[Symbols.visibility]),
+                extensionReceiverType = it[Symbols.extensionReceiverType]?.let(::FqName)
             ) }
     }
 

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -1,34 +1,51 @@
 package org.javacs.kt.index
 
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.name.FqName
-import org.javacs.kt.compiler.Compiler
 import org.javacs.kt.LOG
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.insert
+
+private object Symbols : Table() {
+    val fqName = varchar("fqname", length = 255).autoIncrement().primaryKey()
+    val kind = integer("kind")
+}
 
 /**
  * A global view of all available symbols across all packages.
  */
 class SymbolIndex {
-    val globalDescriptors = ConcurrentHashMap<FqName, DeclarationDescriptor>()
+    private val db = Database.connect("jdbc:h2:mem:symbolindex", "org.h2.Driver")
+
+    init {
+        transaction(db) {
+            SchemaUtils.create(Symbols)
+        }
+    }
 
     fun update(module: ModuleDescriptor) {
         val started = System.currentTimeMillis()
         LOG.info("Updating symbol index...")
 
         try {
-            for (descriptor in allDescriptors(module)) {
-                globalDescriptors[descriptor.fqNameSafe] = descriptor
-            }
+            transaction(db) {
+                for (descriptor in allDescriptors(module)) {
+                    Symbols.insert {
+                        it[fqName] = descriptor.fqNameSafe.toString()
+                        it[kind] = descriptor.accept(ExtractSymbolKind, Unit).rawValue
+                    }
+                }
 
-            val finished = System.currentTimeMillis()
-            LOG.info("Updated symbol index in ${finished - started} ms! (${globalDescriptors.size} symbol(s))")
+                val finished = System.currentTimeMillis()
+                val count = Symbols.slice(Symbols.fqName.count()).selectAll().first()[Symbols.fqName.count()]
+                LOG.info("Updated symbol index in ${finished - started} ms! (${count} symbol(s))")
+            }
         } catch (e: Exception) {
             LOG.error("Error while updating symbol index")
             LOG.printStackTrace(e)

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -1,4 +1,4 @@
-package org.javacs.kt
+package org.javacs.kt.index
 
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.name.FqName
 import org.javacs.kt.compiler.Compiler
+import org.javacs.kt.LOG
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 

--- a/server/src/main/kotlin/org/javacs/kt/progress/LanguageClientProgress.kt
+++ b/server/src/main/kotlin/org/javacs/kt/progress/LanguageClientProgress.kt
@@ -1,2 +1,37 @@
 package org.javacs.kt.progress
 
+import org.eclipse.lsp4j.services.LanguageClient
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.lsp4j.ProgressParams
+import org.eclipse.lsp4j.WorkDoneProgressNotification
+import org.eclipse.lsp4j.WorkDoneProgressBegin
+import org.eclipse.lsp4j.WorkDoneProgressReport
+import org.eclipse.lsp4j.WorkDoneProgressEnd
+
+class LanguageClientProgress(
+    private val label: String,
+    private val token: Either<String, Number>,
+    private val client: LanguageClient
+) : Progress {
+    init {
+        reportProgress(WorkDoneProgressBegin().also {
+            it.title = "Kotlin: $label"
+            it.percentage = 0
+        })
+    }
+
+    override fun update(message: String?, percent: Int?) {
+        reportProgress(WorkDoneProgressReport().also {
+            it.message = message
+            it.percentage = percent
+        })
+    }
+
+    override fun close() {
+        reportProgress(WorkDoneProgressEnd())
+    }
+
+    private fun reportProgress(notification: WorkDoneProgressNotification) {
+        client.notifyProgress(ProgressParams(token, notification))
+    }
+}

--- a/server/src/main/kotlin/org/javacs/kt/progress/LanguageClientProgress.kt
+++ b/server/src/main/kotlin/org/javacs/kt/progress/LanguageClientProgress.kt
@@ -7,6 +7,9 @@ import org.eclipse.lsp4j.WorkDoneProgressNotification
 import org.eclipse.lsp4j.WorkDoneProgressBegin
 import org.eclipse.lsp4j.WorkDoneProgressReport
 import org.eclipse.lsp4j.WorkDoneProgressEnd
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams
+import java.util.concurrent.CompletableFuture
+import java.util.UUID
 
 class LanguageClientProgress(
     private val label: String,
@@ -33,5 +36,16 @@ class LanguageClientProgress(
 
     private fun reportProgress(notification: WorkDoneProgressNotification) {
         client.notifyProgress(ProgressParams(token, notification))
+    }
+
+    class Factory(private val client: LanguageClient) : Progress.Factory {
+        override fun create(label: String): CompletableFuture<Progress> {
+            val token = Either.forLeft<String, Number>(UUID.randomUUID().toString())
+            return client
+                .createProgress(WorkDoneProgressCreateParams().also {
+                    it.token = token
+                })
+                .thenApply { LanguageClientProgress(label, token, client) }
+        }
     }
 }

--- a/server/src/main/kotlin/org/javacs/kt/progress/LanguageClientProgress.kt
+++ b/server/src/main/kotlin/org/javacs/kt/progress/LanguageClientProgress.kt
@@ -1,0 +1,2 @@
+package org.javacs.kt.progress
+

--- a/server/src/main/kotlin/org/javacs/kt/progress/Progress.kt
+++ b/server/src/main/kotlin/org/javacs/kt/progress/Progress.kt
@@ -1,5 +1,21 @@
 package org.javacs.kt.progress
 
-interface Progress {
+import java.io.Closeable
+
+/** A facility for emitting progress notifications. */
+interface Progress : Closeable {
+    /**
+     * Updates the progress percentage. The
+     * value should be in the range [0, 100].
+     */
     fun update(percent: Int): Unit
+
+    interface Factory {
+        /**
+         * Creates a new progress listener with
+         * the given label. The label is intended
+         * to be human-readable.
+         */
+        fun create(label: String): Progress
+    }
 }

--- a/server/src/main/kotlin/org/javacs/kt/progress/Progress.kt
+++ b/server/src/main/kotlin/org/javacs/kt/progress/Progress.kt
@@ -1,6 +1,7 @@
 package org.javacs.kt.progress
 
 import java.io.Closeable
+import java.util.concurrent.CompletableFuture
 
 /** A facility for emitting progress notifications. */
 interface Progress : Closeable {
@@ -8,7 +9,7 @@ interface Progress : Closeable {
      * Updates the progress percentage. The
      * value should be in the range [0, 100].
      */
-    fun update(percent: Int): Unit
+    fun update(message: String? = null, percent: Int? = null)
 
     interface Factory {
         /**
@@ -16,6 +17,6 @@ interface Progress : Closeable {
          * the given label. The label is intended
          * to be human-readable.
          */
-        fun create(label: String): Progress
+        fun create(label: String): CompletableFuture<Progress>
     }
 }

--- a/server/src/main/kotlin/org/javacs/kt/progress/Progress.kt
+++ b/server/src/main/kotlin/org/javacs/kt/progress/Progress.kt
@@ -1,0 +1,5 @@
+package org.javacs.kt.progress
+
+interface Progress {
+    fun update(percent: Int): Unit
+}

--- a/server/src/main/kotlin/org/javacs/kt/progress/Progress.kt
+++ b/server/src/main/kotlin/org/javacs/kt/progress/Progress.kt
@@ -11,6 +11,12 @@ interface Progress : Closeable {
      */
     fun update(message: String? = null, percent: Int? = null)
 
+    object None : Progress {
+        override fun update(message: String?, percent: Int?) {}
+
+        override fun close() {}
+    }
+
     interface Factory {
         /**
          * Creates a new progress listener with
@@ -18,5 +24,9 @@ interface Progress : Closeable {
          * to be human-readable.
          */
         fun create(label: String): CompletableFuture<Progress>
+
+        object None : Factory {
+            override fun create(label: String): CompletableFuture<Progress> = CompletableFuture.completedFuture(Progress.None)
+        }
     }
 }

--- a/server/src/main/resources/kotlinDSLClassPathFinder.gradle
+++ b/server/src/main/resources/kotlinDSLClassPathFinder.gradle
@@ -1,5 +1,5 @@
-import org.gradle.kotlin.dsl.accessors.AccessorsClassPathKt
-import org.gradle.kotlin.dsl.accessors.PluginAccessorsClassPathKt
+import org.gradle.kotlin.dsl.accessors.ProjectAccessorsClassPathGenerator
+import org.gradle.kotlin.dsl.accessors.PluginAccessorClassPathGenerator
 import org.gradle.internal.classpath.ClassPath
 
 allprojects { project ->
@@ -12,12 +12,12 @@ allprojects { project ->
                 .forEach { System.out.println "kotlin-lsp-gradle $it" }
 
             // List dynamically generated Kotlin DSL accessors (e.g. the 'compile' configuration method)
-            AccessorsClassPathKt.projectAccessorsClassPath(project, ClassPath.EMPTY)
+            gradle.services.get(ProjectAccessorsClassPathGenerator.class).projectAccessorsClassPath(project, ClassPath.EMPTY)
                 .bin
                 .asFiles
                 .forEach { System.out.println "kotlin-lsp-gradle $it" }
 
-            PluginAccessorsClassPathKt.pluginSpecBuildersClassPath(project)
+            gradle.services.get(PluginAccessorClassPathGenerator.class).pluginSpecBuildersClassPath(project)
                 .bin
                 .asFiles
                 .forEach { System.out.println "kotlin-lsp-gradle $it" }

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -36,6 +36,7 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
             name = workspaceRoot.fileName.toString()
             uri = workspaceRoot.toUri().toString()
         })
+        languageServer.sourcePath.indexEnabled = false
         languageServer.connect(this)
         languageServer.initialize(init).join()
 


### PR DESCRIPTION
### Fixes #10 

This is some experimental work on indexing the project's globally available symbols in the background and offering completions for them, regardless of whether they have been imported or not:

![image](https://user-images.githubusercontent.com/30873659/109351847-39714580-787a-11eb-97a7-f029f30135e7.png)

Todo:
- [x] Index globally available symbols on a background thread
    - [x] Store visibility in symbol index
- [x] Offer completions for these symbols (WIP)
    - [x] Filter by visibility (public, package-private, ...)
    - [x] Filter out already imported symbols (this includes implicitly imported ones, e.g. from `java.lang`, ...)
        - [x] Handle wildcard imports
    - [x] Automatically add the required imports when selected
        - [x] Find a good import position (e.g. by inserting lexicographically)
    - [x] Offer completions for global/non-imported extension methods/properties
- [x] Add a config option for disabling symbol indexing completely (e.g. for saving memory)
- [x] Fix existing code completion unit tests (may require awaiting the initial symbol indexing)
- [x] Index entire project when language server starts up

Additionally, this branch introduces a new `Progress` abstraction for emitting progress notifications to the client, if supported.

Future ideas, not in the scope of this PR:

- (#270) Store rendered descriptor previews in symbol index
- (#271) Store location URIs in symbol index
- (#271) Use symbol index for workspace symbols and go-to-definition (may require URIs in symbol records, see above)
- (#272) Reindex project incrementally as local files change
- (#273) Reindex entire project when the compiler is reinstantiated, e.g. due to classpath changes