### PR TITLE
Fix Go To Definition for symbols inside jars

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
+++ b/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
@@ -117,6 +117,7 @@ private class CompilationEnvironment(
                 put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, languageVersionSettings)
                 put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, LoggingMessageCollector)
                 add(ComponentRegistrar.PLUGIN_COMPONENT_REGISTRARS, ScriptingCompilerConfigurationComponentRegistrar())
+                put(JVMConfigurationKeys.USE_PSI_CLASS_FILES_READING, true)
 
                 addJvmClasspathRoots(classPath.map { it.toFile() })
                 addJavaSourceRoots(javaSourcePath.map { it.toFile() })


### PR DESCRIPTION
Seems to fix https://github.com/fwcd/kotlin-language-server/issues/263

[This](https://github.com/JetBrains/kotlin/commit/57a674e9e6be67cce2efa5b7352890e9f970ede4#diff-daf7679f3a63204ff6ee82e5fd4b57888298f44b6a39e1d9ee6ba9ba89b7da91L189-R189) might be why it stopped working. Not actually sure 😐 