### PR TITLE
Add support for source JARs with Maven

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -45,7 +45,7 @@ class CompilerClassPath(private val config: CompilerConfiguration) : Closeable {
             }
 
             async.compute {
-                val newClassPathWithSources = resolver.fetchClasspathWithSources()
+                val newClassPathWithSources = resolver.classpathWithSources
                 synchronized(classPath) {
                     syncClassPathEntries(classPath, newClassPathWithSources, "class path")
                 }

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -28,7 +28,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
     val sourcePath = SourcePath(classPath, uriContentProvider, config.indexing)
     val sourceFiles = SourceFiles(sourcePath, uriContentProvider)
 
-    private val textDocuments = KotlinTextDocumentService(sourceFiles, sourcePath, config, tempDirectory, uriContentProvider)
+    private val textDocuments = KotlinTextDocumentService(sourceFiles, sourcePath, config, tempDirectory, uriContentProvider, classPath)
     private val workspaces = KotlinWorkspaceService(sourceFiles, sourcePath, classPath, textDocuments, config)
     private val protocolExtensions = KotlinProtocolExtensionService(uriContentProvider)
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -38,7 +38,8 @@ class KotlinTextDocumentService(
     private val sp: SourcePath,
     private val config: Configuration,
     private val tempDirectory: TemporaryDirectory,
-    private val uriContentProvider: URIContentProvider
+    private val uriContentProvider: URIContentProvider,
+    private val classPath: CompilerClassPath
 ) : TextDocumentService, Closeable {
     private lateinit var client: LanguageClient
     private val async = AsyncExecutor()
@@ -124,7 +125,7 @@ class KotlinTextDocumentService(
             LOG.info("Go-to-definition at {}", describePosition(position))
 
             val (file, cursor) = recover(position, Recompile.NEVER)
-            goToDefinition(file, cursor, uriContentProvider.jarClassContentProvider, tempDirectory, config.externalSources)
+            goToDefinition(file, cursor, uriContentProvider.jarClassContentProvider, tempDirectory, config.externalSources, classPath.classPath)
                 ?.let(::listOf)
                 ?.let { Either.forLeft<List<Location>, List<LocationLink>>(it) }
                 ?: noResult("Couldn't find definition at ${describePosition(position)}", Either.forLeft(emptyList()))

--- a/server/src/main/kotlin/org/javacs/kt/URIContentProvider.kt
+++ b/server/src/main/kotlin/org/javacs/kt/URIContentProvider.kt
@@ -7,6 +7,7 @@ import java.nio.file.Paths
 import org.javacs.kt.externalsources.JarClassContentProvider
 import org.javacs.kt.externalsources.toKlsURI
 import org.javacs.kt.util.KotlinLSException
+import org.javacs.kt.util.partitionAroundLast
 
 /**
  * Fetches the content of Kotlin files identified by a URI.
@@ -16,7 +17,7 @@ class URIContentProvider(
 ) {
     fun contentOf(uri: URI): String = when (uri.scheme) {
         "file" -> Paths.get(uri).toFile().readText()
-        "kls" -> uri.toKlsURI()?.let { jarClassContentProvider.contentOf(it).second }
+        "kls" -> uri.toKlsURI()?.let { jarClassContentProvider.contentOf(it, it.source).second }
             ?: throw KotlinLSException("Could not find ${uri}")
         else -> throw KotlinLSException("Unrecognized scheme ${uri.scheme}")
     }

--- a/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
+++ b/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
@@ -2,9 +2,7 @@ package org.javacs.kt.definition
 
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.Range
-import java.net.URI
 import java.nio.file.Path
-import java.nio.file.Files
 import org.javacs.kt.CompiledFile
 import org.javacs.kt.LOG
 import org.javacs.kt.ExternalSourcesConfiguration
@@ -21,9 +19,6 @@ import org.javacs.kt.util.parseURI
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
-import org.jetbrains.kotlin.js.parser.parse
-import org.jetbrains.kotlin.resolve.descriptorUtil.module
-import java.nio.file.Paths
 
 private val cachedTempFiles = mutableMapOf<KlsURI, Path>()
 private val definitionPattern = Regex("(?:class|interface|object|fun)\\s+(\\w+)")

--- a/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
+++ b/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
@@ -63,7 +63,8 @@ fun goToDefinition(
                     // since the client has not opted into
                     // or does not support KLS URIs
                     val tmpFile = cachedTempFiles[klsSourceURI] ?: run {
-                        val (name, extension) = klsSourceURI.fileName.partitionAroundLast(".")
+                        val (name, rest) = klsSourceURI.fileName.partitionAroundLast(".")
+                        val extension = rest.split("?")[0]
                         tempDir.createTempFile(name, extension)
                             .also {
                                 it.toFile().writeText(content)

--- a/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
+++ b/server/src/main/kotlin/org/javacs/kt/definition/GoToDefinition.kt
@@ -58,8 +58,9 @@ fun goToDefinition(
                     // since the client has not opted into
                     // or does not support KLS URIs
                     val tmpFile = cachedTempFiles[klsSourceURI] ?: run {
-                        val (name, rest) = klsSourceURI.fileName.partitionAroundLast(".")
-                        val extension = rest.split("?")[0]
+                        val name = klsSourceURI.fileName.partitionAroundLast(".").first
+                        val extensionWithoutDot = klsSourceURI.fileExtension
+                        val extension = if (extensionWithoutDot != null) ".$extensionWithoutDot" else ""
                         tempDir.createTempFile(name, extension)
                             .also {
                                 it.toFile().writeText(content)

--- a/server/src/main/kotlin/org/javacs/kt/externalsources/JarClassContentProvider.kt
+++ b/server/src/main/kotlin/org/javacs/kt/externalsources/JarClassContentProvider.kt
@@ -36,7 +36,7 @@ class JarClassContentProvider(
     public fun contentOf(uri: KlsURI, source: Boolean): Pair<KlsURI, String> {
         val key = uri.toString()
         val (contents, extension) = cachedContents[key] ?: run {
-                LOG.info("Finding contents of {}", describeURI(uri.uri))
+                LOG.info("Finding contents of {}", describeURI(uri.fileUri))
                 tryReadContentOf(uri, source)
                     ?: tryReadContentOf(uri.withFileExtension("class"), source)
                     ?: tryReadContentOf(uri.withFileExtension("java"), source)

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 /** Backup classpath that find Kotlin in the user's Maven/Gradle home or kotlinc's libraries folder. */
 object BackupClassPathResolver : ClassPathResolver {
     override val resolverType: String = "Backup"
-    override val classpath: Set<Path> get() = findKotlinStdlib()?.let { setOf(it) }.orEmpty()
+    override val classpath: Set<ClassPathEntry> get() = findKotlinStdlib()?.let { setOf(it) }.orEmpty().map { ClassPathEntry(it, null) }.toSet()
 }
 
 fun findKotlinStdlib(): Path? =

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/ClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/ClassPathResolver.kt
@@ -28,7 +28,7 @@ interface ClassPathResolver {
             emptySet<Path>()
         }
 
-    fun fetchClasspathWithSources(): Set<ClassPathEntry> = classpath
+    val classpathWithSources: Set<ClassPathEntry> get() = classpath
 
     companion object {
         /** A default empty classpath implementation */
@@ -56,7 +56,7 @@ internal class UnionClassPathResolver(val lhs: ClassPathResolver, val rhs: Class
     override val classpathOrEmpty get() = lhs.classpathOrEmpty + rhs.classpathOrEmpty
     override val buildScriptClasspath get() = lhs.buildScriptClasspath + rhs.buildScriptClasspath
     override val buildScriptClasspathOrEmpty get() = lhs.buildScriptClasspathOrEmpty + rhs.buildScriptClasspathOrEmpty
-    override fun fetchClasspathWithSources() = lhs.fetchClasspathWithSources() + rhs.fetchClasspathWithSources()
+    override val classpathWithSources = lhs.classpathWithSources + rhs.classpathWithSources
 }
 
 internal class FirstNonEmptyClassPathResolver(val lhs: ClassPathResolver, val rhs: ClassPathResolver) : ClassPathResolver {
@@ -65,5 +65,5 @@ internal class FirstNonEmptyClassPathResolver(val lhs: ClassPathResolver, val rh
     override val classpathOrEmpty get() = lhs.classpathOrEmpty.takeIf { it.isNotEmpty() } ?: rhs.classpathOrEmpty
     override val buildScriptClasspath get() = lhs.buildScriptClasspath.takeIf { it.isNotEmpty() } ?: rhs.buildScriptClasspath
     override val buildScriptClasspathOrEmpty get() = lhs.buildScriptClasspathOrEmpty.takeIf { it.isNotEmpty() } ?: rhs.buildScriptClasspathOrEmpty
-    override fun fetchClasspathWithSources() = lhs.fetchClasspathWithSources().takeIf { it.isNotEmpty() } ?: rhs.fetchClasspathWithSources()
+    override val classpathWithSources = lhs.classpathWithSources.takeIf { it.isNotEmpty() } ?: rhs.classpathWithSources
 }

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt
@@ -1,8 +1,6 @@
 package org.javacs.kt.classpath
 
 import org.javacs.kt.LOG
-import org.javacs.kt.util.firstNonNull
-import org.javacs.kt.util.tryResolving
 import org.javacs.kt.util.execAndReadStdoutAndStderr
 import org.javacs.kt.util.KotlinLSException
 import org.javacs.kt.util.isOSWindows
@@ -15,12 +13,13 @@ import java.nio.file.Paths
 internal class GradleClassPathResolver(private val path: Path, private val includeKotlinDSL: Boolean): ClassPathResolver {
     override val resolverType: String = "Gradle"
     private val projectDirectory: Path get() = path.getParent()
-    override val classpath: Set<Path> get() {
+    override val classpath: Set<ClassPathEntry> get() {
         val scripts = listOf("projectClassPathFinder.gradle")
         val tasks = listOf("kotlinLSPProjectDeps")
 
         return readDependenciesViaGradleCLI(projectDirectory, scripts, tasks)
             .apply { if (isNotEmpty()) LOG.info("Successfully resolved dependencies for '${projectDirectory.fileName}' using Gradle") }
+            .map { ClassPathEntry(it, null) }.toSet()
     }
     override val buildScriptClasspath: Set<Path> get() {
         return if (includeKotlinDSL) {

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
@@ -103,14 +103,14 @@ private fun mavenJarName(a: Artifact, source: Boolean) =
 
 private fun generateMavenDependencyList(pom: Path): Path {
     val mavenOutput = Files.createTempFile("deps", ".txt")
-    val command = "$mvnCommand dependency:list -DincludeScope=test -DoutputFile=$mavenOutput"
+    val command = "$mvnCommand dependency:list -DincludeScope=test -DoutputFile=$mavenOutput -Dstyle.color=never"
     runCommand(pom, command)
     return mavenOutput
 }
 
 private fun generateMavenDependencySourcesList(pom: Path): Path {
     val mavenOutput = Files.createTempFile("sources", ".txt")
-    val command = "$mvnCommand dependency:sources -DincludeScope=test > $mavenOutput"
+    val command = "$mvnCommand dependency:sources -DincludeScope=test -DoutputFile=$mavenOutput -Dstyle.color=never"
     runCommand(pom, command)
     return mavenOutput
 }
@@ -174,7 +174,7 @@ fun parseMavenArtifact(rawArtifact: String, version: String? = null): Artifact {
 }
 
 fun parseMavenSource(rawArtifact: String, version: String? = null): Artifact? {
-    val parts = rawArtifact.removePrefix("[INFO]").trim().split(':')
+    val parts = rawArtifact.trim().split(':')
 
     return when (parts.size) {
         5 -> if (parts[3] == "sources") Artifact(

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
@@ -28,7 +28,7 @@ internal class MavenClassPathResolver private constructor(private val pom: Path)
         return artifacts.mapNotNull { findMavenArtifact(it, false)?.let { it1 -> ClassPathEntry(it1, null) } }.toSet()
     }
 
-    override fun fetchClasspathWithSources(): Set<ClassPathEntry> {
+    override val classpathWithSources: Set<ClassPathEntry> get() {
         // Fetch artifacts if not yet present.
         var artifacts: Set<Artifact>
         if (this.artifacts != null) {

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathResolver.kt
@@ -12,7 +12,7 @@ internal class ShellClassPathResolver(
     private val workingDir: Path? = null
 ) : ClassPathResolver {
     override val resolverType: String = "Shell"
-    override val classpath: Set<Path> get() {
+    override val classpath: Set<ClassPathEntry> get() {
         val workingDirectory = workingDir?.toFile() ?: script.toAbsolutePath().parent.toFile()
         val cmd = script.toString()
         LOG.info("Run {} in {}", cmd, workingDirectory)
@@ -23,7 +23,7 @@ internal class ShellClassPathResolver(
             .asSequence()
             .map { it.trim() }
             .filter { it.isNotEmpty() }
-            .map { Paths.get(it) }
+            .map { ClassPathEntry(Paths.get(it), null) }
             .toSet()
     }
 

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/WithStdlibResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/WithStdlibResolver.kt
@@ -9,7 +9,7 @@ internal class WithStdlibResolver(private val wrapped: ClassPathResolver) : Clas
     override val classpathOrEmpty: Set<ClassPathEntry> get() = wrapWithStdlibEntries(wrapped.classpathOrEmpty)
     override val buildScriptClasspath: Set<Path> get() = wrapWithStdlib(wrapped.buildScriptClasspath)
     override val buildScriptClasspathOrEmpty: Set<Path> get() = wrapWithStdlib(wrapped.buildScriptClasspathOrEmpty)
-    override fun fetchClasspathWithSources(): Set<ClassPathEntry> = wrapWithStdlibEntries(wrapped.fetchClasspathWithSources())
+    override val classpathWithSources: Set<ClassPathEntry> = wrapWithStdlibEntries(wrapped.classpathWithSources)
 }
 
 private fun wrapWithStdlibEntries(paths: Set<ClassPathEntry>): Set<ClassPathEntry> {

--- a/shared/src/main/kotlin/org/javacs/kt/util/URIs.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/util/URIs.kt
@@ -21,7 +21,9 @@ val URI.fileExtension: String?
     get() {
         val str = toString()
         val dotOffset = str.lastIndexOf(".")
-        return if (dotOffset < 0) null else str.substring(dotOffset + 1)
+        val queryStart = str.indexOf("?")
+        val end = if (queryStart != -1) queryStart else str.length
+        return if (dotOffset < 0) null else str.substring(dotOffset + 1, end)
     }
 
 fun describeURIs(uris: Collection<URI>): String =

--- a/shared/src/main/kotlin/org/javacs/kt/util/Utils.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/util/Utils.kt
@@ -2,12 +2,9 @@ package org.javacs.kt.util
 
 import org.javacs.kt.LOG
 import java.io.PrintStream
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.net.URI
 import java.util.concurrent.CompletableFuture
-import java.util.stream.Stream
 
 fun execAndReadStdout(shellCommand: String, directory: Path): String {
     val process = Runtime.getRuntime().exec(shellCommand, null, directory.toFile())

--- a/shared/src/test/kotlin/org/javacs/kt/MavenArtifactParsingTest.kt
+++ b/shared/src/test/kotlin/org/javacs/kt/MavenArtifactParsingTest.kt
@@ -3,6 +3,7 @@ package org.javacs.kt
 import org.hamcrest.Matchers.*
 import org.javacs.kt.classpath.parseMavenArtifact
 import org.javacs.kt.classpath.Artifact
+import org.javacs.kt.classpath.parseMavenSource
 import org.junit.Assert.assertThat
 import org.junit.Test
 
@@ -15,34 +16,51 @@ class MavenArtifactParsingTest {
             packaging = "jar",
             classifier = "jdk15",
             version = "2.4",
-            scope = "compile"
+            scope = "compile",
+            source = false
         )))
-        
+
         assertThat(parseMavenArtifact("io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.36.Final:compile"), equalTo(Artifact(
             group = "io.netty",
             artifact = "netty-transport-native-epoll",
             packaging = "jar",
             classifier = "linux-x86_64",
             version = "4.1.36.Final",
-            scope = "compile"
+            scope = "compile",
+            source = false
         )))
-        
+
         assertThat(parseMavenArtifact("org.codehaus.mojo:my-project:1.0"), equalTo(Artifact(
             group = "org.codehaus.mojo",
             artifact = "my-project",
             packaging = null,
             classifier = null,
             version = "1.0",
-            scope = null
+            scope = null,
+            source = false
         )))
-        
+
         assertThat(parseMavenArtifact("io.vertx:vertx-sql-client:test-jar:tests:3.8.0-SNAPSHOT:compile"), equalTo(Artifact(
             group = "io.vertx",
             artifact = "vertx-sql-client",
             packaging = "test-jar",
             classifier = "tests",
             version = "3.8.0-SNAPSHOT",
-            scope = "compile"
+            scope = "compile",
+            source = false
+        )))
+    }
+
+    @Test
+    fun `parse maven sources`() {
+        assertThat(parseMavenSource("org.springframework.boot:spring-boot-starter:jar:sources:2.4.5"), equalTo(Artifact(
+            group = "org.springframework.boot",
+            artifact = "spring-boot-starter",
+            packaging = "jar",
+            classifier = null,
+            version = "2.4.5",
+            scope = null,
+            source = true
         )))
     }
 }


### PR DESCRIPTION
This adds supports for source JARs with Maven.

It seems to work fine. I created a data class to hold compiled and source JARs. Source JARs are downloaded asynchronously. The JARs are downloaded using `mvn dependency:sources`.

When a source jar is unavailable we still decompile the bytecode. If the source jar is available, we just open it. This required a new query parameter to be added to the KLS URI, in order for the `jarClassContents` request to be able to know when to decompile and when to fetch the source JAR.

I tested all the features showcased in the README and nothing broke, but I'm sure there's stuff I might have missed. I'll try to test more things if I remember anything I overlooked. If you can think of any other scenarios to test, let me know so I can try them out.

I did not include Gradle support for this yet, since I'm not really sure what the best approach would be there at the moment and I'd prefer to have some feedback regarding the current mechanism before adding Gradle support.

Maybe we should also include a configuration property to enable/disable downloading sources? Not sure if it makes sense.

This would partially complete https://github.com/fwcd/kotlin-language-server/issues/217 (missing Gradle support)