### PR TITLE
Update semantic tokens asynchronously

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -231,9 +231,10 @@ class KotlinTextDocumentService(
 
         reportTime {
             val uri = parseURI(params.textDocument.uri)
-            val file = sp.currentVersion(uri)
+            val parse = sp.parsedFile(uri)
+            val file = sp.latestCompiledVersion(uri)
 
-            val tokens = encodedSemanticTokens(file)
+            val tokens = encodedSemanticTokens(parse, file.compile)
             LOG.info("Found {} tokens", tokens.size)
 
             SemanticTokens(tokens)
@@ -245,9 +246,10 @@ class KotlinTextDocumentService(
 
         reportTime {
             val uri = parseURI(params.textDocument.uri)
-            val file = sp.currentVersion(uri)
+            val parse = sp.parsedFile(uri)
+            val file = sp.latestCompiledVersion(uri)
 
-            val tokens = encodedSemanticTokens(file, params.range)
+            val tokens = encodedSemanticTokens(parse, file.compile, params.range)
             LOG.info("Found {} tokens", tokens.size)
 
             SemanticTokens(tokens)
@@ -288,6 +290,7 @@ class KotlinTextDocumentService(
         val context = sp.compileFiles(files)
         if (!cancelCallback.invoke()) {
             reportDiagnostics(files, context.diagnostics)
+            client.refreshSemanticTokens()
         }
         lintCount++
     }

--- a/server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt
+++ b/server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
@@ -71,15 +72,15 @@ data class SemanticToken(val range: Range, val type: SemanticTokenType, val modi
  * Computes LSP-encoded semantic tokens for the given range in the
  * document. No range means the entire document.
  */
-fun encodedSemanticTokens(file: CompiledFile, range: Range? = null): List<Int> =
-    encodeTokens(semanticTokens(file, range))
+fun encodedSemanticTokens(parse: KtFile, bindingContext: BindingContext, range: Range? = null): List<Int> =
+    encodeTokens(semanticTokens(parse, bindingContext, range))
 
 /**
  * Computes semantic tokens for the given range in the document.
  * No range means the entire document.
  */
-fun semanticTokens(file: CompiledFile, range: Range? = null): Sequence<SemanticToken> =
-    elementTokens(file.parse, file.compile, range)
+fun semanticTokens(parse: KtFile, bindingContext: BindingContext, range: Range? = null): Sequence<SemanticToken> =
+    elementTokens(parse, bindingContext, range)
 
 fun encodeTokens(tokens: Sequence<SemanticToken>): List<Int> {
     val encoded = mutableListOf<Int>()


### PR DESCRIPTION
Instead of recompiling the document every time semantic tokens are requested, update them asynchronously together with the linter and notify the client once new tokens are ready.

This has the advantage of making the editor feel more responsive, may however also cause tokens to 'flicker' since a fresh `BindingContext` might be unavailable and thus cause an incomplete highlighting.