### PR TITLE
Fix Go To Definition

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/externalsources/JarClassContentProvider.kt
+++ b/server/src/main/kotlin/org/javacs/kt/externalsources/JarClassContentProvider.kt
@@ -56,7 +56,7 @@ class JarClassContentProvider(
     }
 
     private fun tryReadContentOf(uri: KlsURI): Pair<String, String>? = try {
-        val actualUri = KlsURI(uri.fileUri, mapOf())
+        val actualUri = uri.withoutQuery()
         when (actualUri.fileExtension) {
             "class" -> Pair(actualUri.extractToTemporaryFile(tempDir)
                 .let(decompiler::decompileClass)

--- a/server/src/main/kotlin/org/javacs/kt/externalsources/JarClassContentProvider.kt
+++ b/server/src/main/kotlin/org/javacs/kt/externalsources/JarClassContentProvider.kt
@@ -56,16 +56,15 @@ class JarClassContentProvider(
     }
 
     private fun tryReadContentOf(uri: KlsURI): Pair<String, String>? = try {
-        val actualUri = uri.withoutQuery()
-        when (actualUri.fileExtension) {
-            "class" -> Pair(actualUri.extractToTemporaryFile(tempDir)
+        when (uri.fileExtension) {
+            "class" -> Pair(uri.extractToTemporaryFile(tempDir)
                 .let(decompiler::decompileClass)
                 .let { Files.newInputStream(it) }
                 .bufferedReader()
                 .use(BufferedReader::readText)
                 .let(this::convertToKotlinIfNeeded), if (config.autoConvertToKotlin) "kt" else "java")
-            "java" -> if (uri.source) Pair(actualUri.readContents(), "java") else Pair(convertToKotlinIfNeeded(actualUri.readContents()), "kt")
-            else -> Pair(actualUri.readContents(), "kt") // e.g. for Kotlin source files
+            "java" -> if (uri.source) Pair(uri.readContents(), "java") else Pair(convertToKotlinIfNeeded(uri.readContents()), "kt")
+            else -> Pair(uri.readContents(), "kt") // e.g. for Kotlin source files
         }
     } catch (e: FileNotFoundException) { null }
 }

--- a/server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt
+++ b/server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt
@@ -54,7 +54,7 @@ data class KlsURI(val fileUri: URI, val query: Map<QueryParam, String>) {
         get() = fileUri.schemeSpecificPart.split("!", limit = 2).get(1)
 
     val source: Boolean
-        get() = query[QueryParam.SOURCE].toBoolean()
+        get() = query[QueryParam.SOURCE]?.toBoolean() ?: false
     val isCompiled: Boolean
         get() = fileExtension == "class"
 

--- a/server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt
+++ b/server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt
@@ -83,6 +83,8 @@ data class KlsURI(val fileUri: URI, val query: Map<QueryParam, Any>) {
         return KlsURI(fileUri, newQuery)
     }
 
+    fun withoutQuery(): KlsURI = KlsURI(fileUri, mapOf())
+
     fun toURI(): URI = URI(fileUri.toString() + queryString)
 
     private fun toJarURL(): URL = URL("jar:${fileUri.schemeSpecificPart}")

--- a/server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt
+++ b/server/src/main/kotlin/org/javacs/kt/externalsources/KlsURI.kt
@@ -77,8 +77,6 @@ data class KlsURI(val fileUri: URI, val query: Map<QueryParam, String>) {
         return KlsURI(fileUri, newQuery)
     }
 
-    fun withoutQuery(): KlsURI = KlsURI(fileUri, mapOf())
-
     fun toURI(): URI = URI(fileUri.toString() + queryString)
 
     private fun toJarURL(): URL = URL("jar:${fileUri.schemeSpecificPart}")


### PR DESCRIPTION
Fixes https://github.com/fwcd/kotlin-language-server/issues/297

This ended up taking a lot more trouble than I expected 😬 

So apparently, `Paths.get` fails when a URI scheme is given (at least on Windows). Although we're using the `schemeSpecificPart`, this still includes the `file://` because we're using a KLS URI and only the first `kls:` is removed there.

After fixing this, I got another issue because the path being sent to `withJarPath` is not a KLS URI. I convert it to KLS before returning the new one now.

After this, I noticed the source parameter logic was gone (I think it was removed by accident). I re-added it to the places where it made sense to me.

Finally, for some reason the source parameter cast doesn't work anymore (we were casting from Any to Boolean but it failed, leading to a false value even when the source parameter was true). I changed this and now it works fine. Not really sure what happened (maybe Kotlin 1.5? 🤷)