### PR TITLE
Sort found references

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt
+++ b/server/src/main/kotlin/org/javacs/kt/references/FindReferences.kt
@@ -28,6 +28,7 @@ fun findReferences(file: Path, cursor: Int, sp: SourcePath): List<Location> {
             .map { location(it) }
             .filterNotNull()
             .toList()
+            .sortedWith(compareBy({ it.getUri() }, { it.getRange().getStart().getLine() }))
 }
 
 private fun doFindReferences(file: Path, cursor: Int, sp: SourcePath): Collection<KtElement> {


### PR DESCRIPTION
The references returned tend to be in a random order; this PR sorts them by file/line number.

E.g., before this change:
<img width="953" alt="kotlin-log-info-old" src="https://user-images.githubusercontent.com/147591/134706854-487138da-c773-4ec6-b59a-f1c683ac55d6.png">

After this change:
<img width="968" alt="kotlin-log-info-new" src="https://user-images.githubusercontent.com/147591/134706901-cf947980-9276-40a5-8063-277af3013e33.png">


