### PR TITLE
Improved region-comment folding support; fixes #306

### DIFF
--- a/grammars/kotlin.configuration.json
+++ b/grammars/kotlin.configuration.json
@@ -28,8 +28,8 @@
    "folding": {
         "offSide": true,
         "markers": {
-            "start": "^\\s*//\\s*#region",
-            "end": "^\\s*//\\s*#endregion"
+            "start": "^\\s*//\\s*#?region",
+            "end": "^\\s*//\\s*#?endregion"
         }
     }
 }


### PR DESCRIPTION
Improves region-comment folding support; fixes #306

`// #region regionName` & `// #endregion` works, but `//region regionName` & `//endregion` doesn't;  
This pull request fixes this.