### PR TITLE
ShellClassPathResolver Windows/MinGW/MSYS Support

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/ShellClassPathResolver.kt
@@ -4,6 +4,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import org.javacs.kt.util.userHome
+import org.javacs.kt.util.isOSWindows
+import org.javacs.kt.util.execAndReadStdoutAndStderr
 import org.javacs.kt.LOG
 
 /** Executes a shell script to determine the classpath */
@@ -13,13 +15,16 @@ internal class ShellClassPathResolver(
 ) : ClassPathResolver {
     override val resolverType: String = "Shell"
     override val classpath: Set<ClassPathEntry> get() {
-        val workingDirectory = workingDir?.toFile() ?: script.toAbsolutePath().parent.toFile()
+        val workingDirectory = workingDir ?: script.toAbsolutePath().parent
         val cmd = script.toString()
         LOG.info("Run {} in {}", cmd, workingDirectory)
-        val process = Runtime.getRuntime().exec(cmd, null, workingDirectory)
+        val (result, errors) = execAndReadStdoutAndStderr(cmd, workingDirectory)
+        if (errors.isNotBlank()) {
+            LOG.warn("ShellClassPathResolver {} stderr: {}", cmd, errors.lines().joinToString("\n"))
+        }
 
-        return process.inputStream.bufferedReader().readText()
-            .split(':')
+        return result
+            .split(separatorChar)
             .asSequence()
             .map { it.trim() }
             .filter { it.isNotEmpty() }
@@ -28,9 +33,12 @@ internal class ShellClassPathResolver(
     }
 
     companion object {
+        private val execExtension = if (isOSWindows()) "bat" else "sh"
+        private val separatorChar = if (isOSWindows()) ';' else ':' 
+
         /** Create a shell resolver if a file is a pom. */
         fun maybeCreate(file: Path): ShellClassPathResolver? =
-            file.takeIf { it.endsWith("kotlinLspClasspath.sh") }?.let { ShellClassPathResolver(it) }
+            file.takeIf { it.endsWith("kotlinLspClasspath." + execExtension) }?.let { ShellClassPathResolver(it) }
 
         /** The root directory for config files. */
         private val globalConfigRoot: Path =
@@ -38,7 +46,7 @@ internal class ShellClassPathResolver(
 
         /** Returns the ShellClassPathResolver for the global home directory shell script. */
         fun global(workingDir: Path?): ClassPathResolver =
-            globalConfigRoot.resolve("KotlinLanguageServer").resolve("classpath.sh")
+            globalConfigRoot.resolve("KotlinLanguageServer").resolve("classpath." + execExtension)
                 .takeIf { Files.exists(it) }
                 ?.let { ShellClassPathResolver(it, workingDir) }
                 ?: ClassPathResolver.empty


### PR DESCRIPTION
ShellClassPathResolver will look for kotlinLspClasspath.bat in project's root (and classpath.bat globally in user's home folder) instead of '.sh' shell executables.

JVM will throw `Cannot run program "...\kotlinLspClasspath.sh" (in directory "..."): CreateProcess error=193, %1 is not a valid Win32 application` exception when executing shell executable on Windows based MSYS/MinGW. I could not find a more elegant way to deal with this except using a separate batch file executable on Windows.

This ShellClassPathResolver (@Nycto added this capability in 2019)  is somehow hidden in the code base here, I think we need to add a bit of documentation to the main readme file regarding the usage.