### PR TITLE
Implement Rename

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -76,6 +76,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         serverCapabilities.workspace.workspaceFolders.supported = true
         serverCapabilities.workspace.workspaceFolders.changeNotifications = Either.forRight(true)
         serverCapabilities.hoverProvider = Either.forLeft(true)
+        serverCapabilities.renameProvider = Either.forLeft(true)
         serverCapabilities.completionProvider = CompletionOptions(false, listOf("."))
         serverCapabilities.signatureHelpProvider = SignatureHelpOptions(listOf("(", ","))
         serverCapabilities.definitionProvider = Either.forLeft(true)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -26,6 +26,7 @@ import org.javacs.kt.util.parseURI
 import org.javacs.kt.util.describeURI
 import org.javacs.kt.util.describeURIs
 import org.javacs.kt.commands.JAVA_TO_KOTLIN_COMMAND
+import org.javacs.kt.rename.renameSymbol
 import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
 import java.net.URI
 import java.io.Closeable
@@ -144,8 +145,9 @@ class KotlinTextDocumentService(
         TODO("not implemented")
     }
 
-    override fun rename(params: RenameParams): CompletableFuture<WorkspaceEdit> {
-        TODO("not implemented")
+    override fun rename(params: RenameParams) = async.compute {
+        val (file, cursor) = recover(params, Recompile.NEVER)
+        renameSymbol(file, cursor, sp, params.newName)
     }
 
     override fun completion(position: CompletionParams) = async.compute {

--- a/server/src/main/kotlin/org/javacs/kt/rename/Rename.kt
+++ b/server/src/main/kotlin/org/javacs/kt/rename/Rename.kt
@@ -1,0 +1,44 @@
+package org.javacs.kt.rename
+
+import org.eclipse.lsp4j.*
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.javacs.kt.CompiledFile
+import org.javacs.kt.SourcePath
+import org.javacs.kt.position.location
+import org.javacs.kt.references.findReferences
+import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+
+fun renameSymbol(file: CompiledFile, cursor: Int, sp: SourcePath, newName: String): WorkspaceEdit? {
+    val (declaration, location) = findDeclaration(file, cursor) ?: return null
+    return declaration.let {
+        val declarationEdit = Either.forLeft<TextDocumentEdit, ResourceOperation>(TextDocumentEdit(
+            VersionedTextDocumentIdentifier().apply { uri = location.uri },
+            listOf(TextEdit(location.range, newName))
+        ))
+
+        val referenceEdits = findReferences(declaration, sp).map {
+            Either.forLeft<TextDocumentEdit, ResourceOperation>(TextDocumentEdit(
+                VersionedTextDocumentIdentifier().apply { uri = it.uri },
+                listOf(TextEdit(it.range, newName))
+            ))
+        }
+
+        WorkspaceEdit(listOf(declarationEdit) + referenceEdits)
+    }
+}
+
+private fun findDeclaration(file: CompiledFile, cursor: Int): Pair<KtNamedDeclaration, Location>? {
+    val (_, target) = file.referenceAtPoint(cursor) ?: return null
+    val psi = target.findPsi()
+
+    return if (psi is KtNamedDeclaration) {
+        psi.nameIdentifier?.let {
+            location(it)?.let { location ->
+                Pair(psi, location)
+            }
+        }
+    } else {
+        null
+    }
+}

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -54,6 +54,9 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
         println("Memory after test: ${total - free} MB used / $total MB total")
     }
 
+    fun renameParams(relativePath: String, line: Int, column: Int, newName: String): RenameParams =
+        textDocumentPosition(relativePath, line, column).run { RenameParams(textDocument, position, newName) }
+
     fun completionParams(relativePath: String, line: Int, column: Int): CompletionParams {
         val file = workspaceRoot.resolve(relativePath)
         val fileId = TextDocumentIdentifier(file.toUri().toString())

--- a/server/src/test/kotlin/org/javacs/kt/RenameTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/RenameTest.kt
@@ -1,0 +1,45 @@
+package org.javacs.kt
+
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.hasProperty
+import org.hamcrest.Matchers.hasSize
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+class RenameReferenceTest : SingleFileTestFixture("rename", "SomeClass.kt") {
+
+    @Test
+    fun `rename in the reference`() {
+        val edits = languageServer.textDocumentService.rename(renameParams(file, 4, 26, "NewClassName")).get()!!
+        val changes = edits.documentChanges
+
+        assertThat(changes.size, equalTo(3))
+        assertThat(changes[0].left.textDocument.uri, containsString("SomeOtherClass.kt"))
+
+        assertThat(changes[0].left.edits[0].newText, equalTo("NewClassName"))
+        assertThat(changes[0].left.edits[0].range.start, equalTo(Position(2, 6)))
+        assertThat(changes[0].left.edits[0].range.end, equalTo(Position(2, 20)))
+    }
+}
+
+class RenameDefinitionTest : SingleFileTestFixture("rename", "SomeOtherClass.kt") {
+
+    @Test
+    fun `rename in the definition`() {
+        val edits = languageServer.textDocumentService.rename(renameParams(file, 2, 15, "NewClassName")).get()!!
+        val changes = edits.documentChanges
+
+        println(changes)
+
+        assertThat(changes.size, equalTo(3))
+        assertThat(changes[0].left.textDocument.uri, containsString("SomeOtherClass.kt"))
+
+        assertThat(changes[0].left.edits[0].newText, equalTo("NewClassName"))
+        assertThat(changes[0].left.edits[0].range.start, equalTo(Position(2, 6)))
+        assertThat(changes[0].left.edits[0].range.end, equalTo(Position(2, 20)))
+    }
+}

--- a/server/src/test/resources/rename/SomeClass.kt
+++ b/server/src/test/resources/rename/SomeClass.kt
@@ -1,0 +1,6 @@
+package rename
+
+class SomeClass {
+
+    val something: SomeOtherClass = SomeOtherClass()
+}

--- a/server/src/test/resources/rename/SomeOtherClass.kt
+++ b/server/src/test/resources/rename/SomeOtherClass.kt
@@ -1,0 +1,4 @@
+package rename
+
+class SomeOtherClass {
+}


### PR DESCRIPTION
Fixes https://github.com/fwcd/kotlin-language-server/issues/16

Rename works when you request it on the definition of a symbol, but also when you request it on one of the references. It therefore leverages the existing logic for definitions and references.

While I was testing this, I noticed that the references don't always work (e.g., they work fine for classes but not for method arguments). This obviously has an impact on the rename.