### PR TITLE
Implement Abstract Functions Quick Fix

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -4,6 +4,7 @@ import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.services.TextDocumentService
+import org.javacs.kt.codeaction.codeActions
 import org.javacs.kt.completion.*
 import org.javacs.kt.definition.goToDefinition
 import org.javacs.kt.diagnostic.convertDiagnostic
@@ -74,9 +75,13 @@ class KotlinTextDocumentService(
     }
 
     private fun recover(position: TextDocumentPositionParams, recompile: Recompile): Pair<CompiledFile, Int> {
-        val uri = parseURI(position.textDocument.uri)
+        return recover(position.textDocument.uri, position.position, recompile)
+    }
+
+    private fun recover(uriString: String, position: Position, recompile: Recompile): Pair<CompiledFile, Int> {
+        val uri = parseURI(uriString)
         val content = sp.content(uri)
-        val offset = offset(content, position.position.line, position.position.character)
+        val offset = offset(content, position.line, position.character)
         val shouldRecompile = when (recompile) {
             Recompile.ALWAYS -> true
             Recompile.AFTER_DOT -> offset > 0 && content[offset - 1] == '.'
@@ -87,21 +92,8 @@ class KotlinTextDocumentService(
     }
 
     override fun codeAction(params: CodeActionParams): CompletableFuture<List<Either<Command, CodeAction>>> = async.compute {
-        val start = params.range.start
-        val end = params.range.end
-        val hasSelection = (end.character - start.character) != 0 || (end.line - start.line) != 0
-        if (hasSelection) {
-            listOf(
-                Either.forLeft<Command, CodeAction>(
-                    Command("Convert Java to Kotlin", JAVA_TO_KOTLIN_COMMAND, listOf(
-                        params.textDocument.uri,
-                        params.range
-                    ))
-                )
-            )
-        } else {
-            emptyList()
-        }
+        val (file, _) = recover(params.textDocument.uri, params.range.start, Recompile.NEVER)
+        codeActions(file, params.range, params.context)
     }
 
     override fun hover(position: HoverParams): CompletableFuture<Hover?> = async.compute {

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/CodeAction.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/CodeAction.kt
@@ -1,0 +1,45 @@
+package org.javacs.kt.codeaction
+
+import org.eclipse.lsp4j.*
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.javacs.kt.CompiledFile
+import org.javacs.kt.codeaction.quickfixes.ImplementAbstractFunctionsQuickFix
+import org.javacs.kt.commands.JAVA_TO_KOTLIN_COMMAND
+import org.javacs.kt.util.toPath
+
+val QUICK_FIXES = listOf(
+    ImplementAbstractFunctionsQuickFix()
+)
+
+fun codeActions(file: CompiledFile, range: Range, context: CodeActionContext): List<Either<Command, CodeAction>> {
+    val requestedKinds = context.only ?: listOf(CodeActionKind.Refactor)
+    return requestedKinds.map {
+        when (it) {
+            CodeActionKind.Refactor -> getRefactors(file, range)
+            CodeActionKind.QuickFix -> getQuickFixes(file, range, context.diagnostics)
+            else -> listOf()
+        }
+    }.flatten()
+}
+
+fun getRefactors(file: CompiledFile, range: Range): List<Either<Command, CodeAction>> {
+    val hasSelection = (range.end.line - range.start.line) != 0 || (range.end.character - range.start.character) != 0
+    return if (hasSelection) {
+        listOf(
+            Either.forLeft<Command, CodeAction>(
+                Command("Convert Java to Kotlin", JAVA_TO_KOTLIN_COMMAND, listOf(
+                    file.parse.toPath().toUri().toString(),
+                    range
+                ))
+            )
+        )
+    } else {
+        emptyList()
+    }
+}
+
+fun getQuickFixes(file: CompiledFile, range: Range, diagnostics: List<Diagnostic>): List<Either<Command, CodeAction>> {
+    return QUICK_FIXES.mapNotNull {
+        it.compute(file, range, diagnostics)
+    }
+}

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfixes/ImplementAbstractFunctionsQuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfixes/ImplementAbstractFunctionsQuickFix.kt
@@ -1,0 +1,160 @@
+package org.javacs.kt.codeaction.quickfixes
+
+import org.eclipse.lsp4j.*
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.javacs.kt.CompiledFile
+import org.javacs.kt.position.offset
+import org.javacs.kt.position.position
+import org.javacs.kt.util.toPath
+import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.isAbstract
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
+
+private const val DEFAULT_TAB_SIZE = 4
+
+class ImplementAbstractFunctionsQuickFix : QuickFix {
+
+    override fun compute(file: CompiledFile, range: Range, diagnostics: List<Diagnostic>): Either<Command, CodeAction>? {
+        val diagnostic = findDiagnosticMatch(diagnostics, range)
+
+        val startCursor = offset(file.content, range.start)
+        val endCursor = offset(file.content, range.end)
+        val kotlinDiagnostics = file.compile.diagnostics
+
+        // If the client side and the server side diagnostics contain a valid diagnostic for this range.
+        if (diagnostic != null && anyDiagnosticMatch(kotlinDiagnostics, startCursor, endCursor)) {
+            // Get the class with the missing functions
+            val kotlinClass = file.parseAtPoint(startCursor)
+            if (kotlinClass is KtClass) {
+                // Get the functions that need to be implemented
+                val functionsToImplement = getAbstractFunctionStubs(file, kotlinClass)
+
+                val uri = file.parse.toPath().toUri().toString()
+                // Get the padding to be introduced before the function declarations
+                val padding = getDeclarationPadding(file, kotlinClass)
+                // Get the location where the new code will be placed
+                val newFunctionStartPosition = getNewFunctionStartPosition(file, kotlinClass)
+
+                val textEdits = functionsToImplement.map {
+                    // We leave two new lines before the function is inserted
+                    val newText = System.lineSeparator() + System.lineSeparator() + padding + it
+                    TextEdit(Range(newFunctionStartPosition, newFunctionStartPosition), newText)
+                }
+
+                val codeAction = CodeAction()
+                codeAction.edit = WorkspaceEdit(mapOf(uri to textEdits))
+                codeAction.kind = CodeActionKind.QuickFix
+                codeAction.title = "Implement abstract functions"
+                codeAction.diagnostics = listOf(diagnostic)
+                return Either.forRight(codeAction)
+            }
+        }
+        return null
+    }
+}
+
+fun findDiagnosticMatch(diagnostics: List<Diagnostic>, range: Range) =
+    diagnostics.find { diagnosticMatch(it, range, hashSetOf("ABSTRACT_MEMBER_NOT_IMPLEMENTED", "ABSTRACT_CLASS_MEMBER_NOT_IMPLEMENTED")) }
+
+private fun anyDiagnosticMatch(diagnostics: Diagnostics, startCursor: Int, endCursor: Int) =
+    diagnostics.any { diagnosticMatch(it, startCursor, endCursor, hashSetOf("ABSTRACT_MEMBER_NOT_IMPLEMENTED", "ABSTRACT_CLASS_MEMBER_NOT_IMPLEMENTED")) }
+
+private fun getAbstractFunctionStubs(file: CompiledFile, kotlinClass: KtClass) =
+    // For each of the super types used by this class
+    kotlinClass.superTypeListEntries.mapNotNull {
+        // Find the definition of this super type
+        val descriptor = file.referenceAtPoint(it.startOffset)?.second
+        val superClass = descriptor?.findPsi()
+        // If the super class is abstract or an interface
+        if (superClass is KtClass && (superClass.isAbstract() || superClass.isInterface())) {
+            // Get the abstract functions of this super type that are currently not implemented by this class
+            val abstractFunctions = superClass.declarations.filter {
+                declaration -> isAbstractFunction(declaration) && !overridesDeclaration(kotlinClass, declaration)
+            }
+            // Get stubs for each function
+            abstractFunctions.map { function -> getFunctionStub(function as KtNamedFunction) }
+        } else {
+            null
+        }
+    }.flatten()
+
+private fun isAbstractFunction(declaration: KtDeclaration): Boolean =
+    declaration is KtNamedFunction && !declaration.hasBody()
+        && (declaration.containingClass()?.isInterface() ?: false || declaration.hasModifier(KtTokens.ABSTRACT_KEYWORD))
+
+// Checks if the class overrides the given declaration
+private fun overridesDeclaration(kotlinClass: KtClass, declaration: KtDeclaration): Boolean =
+    kotlinClass.declarations.any {
+        if (it.name == declaration.name && it.hasModifier(KtTokens.OVERRIDE_KEYWORD)) {
+            if (it is KtNamedFunction && declaration is KtNamedFunction) {
+                parametersMatch(it, declaration)
+            } else {
+                true
+            }
+        } else {
+            false
+        }
+    }
+
+// Checks if two functions have matching parameters
+private fun parametersMatch(function: KtNamedFunction, functionDeclaration: KtNamedFunction): Boolean {
+    if (function.valueParameters.size == functionDeclaration.valueParameters.size) {
+        for (index in 0 until function.valueParameters.size) {
+            if (function.valueParameters[index].name != functionDeclaration.valueParameters[index].name) {
+                return false
+            } else if (function.valueParameters[index].typeReference?.name != functionDeclaration.valueParameters[index].typeReference?.name) {
+                return false
+            }
+        }
+
+        if (function.typeParameters.size == functionDeclaration.typeParameters.size) {
+            for (index in 0 until function.typeParameters.size) {
+                if (function.typeParameters[index].variance != functionDeclaration.typeParameters[index].variance) {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+
+    return false
+}
+
+private fun getFunctionStub(function: KtNamedFunction): String =
+    "override fun" + function.text.substringAfter("fun") + " { }"
+
+private fun getDeclarationPadding(file: CompiledFile, kotlinClass: KtClass): String {
+    // If the class is not empty, the amount of padding is the same as the one in the last declaration of the class
+    val paddingSize = if (kotlinClass.declarations.isNotEmpty()) {
+        val lastFunctionStartOffset = kotlinClass.declarations.last().startOffset
+        position(file.content, lastFunctionStartOffset).character
+    } else {
+        // Otherwise, we just use a default tab size in addition to any existing padding
+        // on the class itself (note that the class could be inside another class, for example)
+        position(file.content, kotlinClass.startOffset).character + DEFAULT_TAB_SIZE
+    }
+
+    return " ".repeat(paddingSize)
+}
+
+private fun getNewFunctionStartPosition(file: CompiledFile, kotlinClass: KtClass): Position? =
+    // If the class is not empty, the new function will be put right after the last declaration
+    if (kotlinClass.declarations.isNotEmpty()) {
+        val lastFunctionEndOffset = kotlinClass.declarations.last().endOffset
+        position(file.content, lastFunctionEndOffset)
+    } else { // Otherwise, the function is put at the beginning of the class
+        val body = kotlinClass.body
+        if (body != null) {
+            position(file.content, body.startOffset + 1)
+        } else {
+            null
+        }
+    }

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfixes/QuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfixes/QuickFix.kt
@@ -1,0 +1,28 @@
+package org.javacs.kt.codeaction.quickfixes
+
+import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.Command
+import org.eclipse.lsp4j.Diagnostic
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.javacs.kt.CompiledFile
+import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
+import org.jetbrains.kotlin.diagnostics.Diagnostic as KotlinDiagnostic
+
+interface QuickFix {
+
+    // Computes the quickfix. Return null if the quickfix is not valid.
+    fun compute(file: CompiledFile, range: Range, diagnostics: List<Diagnostic>): Either<Command, CodeAction>?
+}
+
+fun diagnosticMatch(diagnostic: Diagnostic, range: Range, diagnosticTypes: HashSet<String>): Boolean =
+    diagnostic.range.equals(range) && diagnosticTypes.contains(diagnostic.code.left)
+
+fun diagnosticMatch(diagnostic: KotlinDiagnostic, startCursor: Int, endCursor: Int, diagnosticTypes: HashSet<String>): Boolean =
+    diagnostic.textRanges.any { it.startOffset == startCursor && it.endOffset == endCursor } && diagnosticTypes.contains(diagnostic.factory.name)
+
+fun findDiagnosticMatch(diagnostics: List<Diagnostic>, range: Range, diagnosticTypes: HashSet<String>) =
+    diagnostics.find { diagnosticMatch(it, range, diagnosticTypes) }
+
+fun anyDiagnosticMatch(diagnostics: Diagnostics, startCursor: Int, endCursor: Int, diagnosticTypes: HashSet<String>) =
+    diagnostics.any { diagnosticMatch(it, startCursor, endCursor, diagnosticTypes) }

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -68,6 +68,15 @@ abstract class LanguageServerTestFixture(relativeWorkspaceRoot: String) : Langua
     fun textDocumentPosition(relativePath: String, line: Int, column: Int): TextDocumentPositionParams =
         textDocumentPosition(relativePath, position(line, column))
 
+    fun codeActionParams(relativePath: String, startLine: Int, startColumn: Int, endLine: Int, endColumn: Int, diagnostics: List<Diagnostic>, only: List<String>): CodeActionParams {
+        val file = workspaceRoot.resolve(relativePath)
+        val fileId = TextDocumentIdentifier(file.toUri().toString())
+        val range = range(startLine, startColumn, endLine, endColumn)
+        val context = CodeActionContext(diagnostics, only)
+
+        return CodeActionParams(fileId, range, context)
+    }
+
     fun hoverParams(relativePath: String, line: Int, column: Int): HoverParams =
         textDocumentPosition(relativePath, line, column).run { HoverParams(textDocument, position) }
 

--- a/server/src/test/kotlin/org/javacs/kt/QuickFixesTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/QuickFixesTest.kt
@@ -1,0 +1,90 @@
+package org.javacs.kt
+
+import org.eclipse.lsp4j.CodeActionKind
+import org.eclipse.lsp4j.Diagnostic
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.hamcrest.Matchers
+import org.junit.Assert
+import org.junit.Test
+
+class ImplementAbstractFunctionsQuickFixTest : SingleFileTestFixture("quickfixes", "SomeSubclass.kt") {
+    @Test
+    fun `gets workspace edit for all abstract methods when none are implemented`() {
+        val diagnostic = Diagnostic(range(3, 1, 3, 19), "")
+        diagnostic.code = Either.forLeft("ABSTRACT_CLASS_MEMBER_NOT_IMPLEMENTED")
+        val codeActionParams = codeActionParams(file, 3, 1, 3, 19, listOf(diagnostic), listOf(CodeActionKind.QuickFix))
+
+        val codeActions = languageServer.textDocumentService.codeAction(codeActionParams).get()
+
+        Assert.assertThat(codeActions.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.kind, Matchers.equalTo(CodeActionKind.QuickFix))
+        Assert.assertThat(codeActions[0].right.diagnostics.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.diagnostics[0], Matchers.equalTo(diagnostic))
+        Assert.assertThat(codeActions[0].right.edit.changes.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.size, Matchers.equalTo(2))
+        Assert.assertThat(
+            codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.get(0)?.range,
+            Matchers.equalTo(range(3, 55, 3, 55))
+        )
+        Assert.assertThat(
+            codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.get(0)?.newText,
+            Matchers.equalTo(System.lineSeparator() + System.lineSeparator() + "    override fun someSuperMethod(someParameter: String): Int { }")
+        )
+        Assert.assertThat(
+            codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.get(1)?.range,
+            Matchers.equalTo(range(3, 55, 3, 55))
+        )
+        Assert.assertThat(
+            codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.get(1)?.newText,
+            Matchers.equalTo(System.lineSeparator() + System.lineSeparator() + "    override fun someInterfaceMethod() { }")
+        )
+    }
+
+    @Test
+    fun `gets workspace edit for interface methods when super class abstract methods are implemented`() {
+        val diagnostic = Diagnostic(range(6, 1, 6, 24), "")
+        diagnostic.code = Either.forLeft("ABSTRACT_MEMBER_NOT_IMPLEMENTED")
+        val codeActionParams = codeActionParams(file, 6, 1, 6, 24, listOf(diagnostic), listOf(CodeActionKind.QuickFix))
+
+        val codeActions = languageServer.textDocumentService.codeAction(codeActionParams).get()
+
+        Assert.assertThat(codeActions.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.kind, Matchers.equalTo(CodeActionKind.QuickFix))
+        Assert.assertThat(codeActions[0].right.diagnostics.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.diagnostics[0], Matchers.equalTo(diagnostic))
+        Assert.assertThat(codeActions[0].right.edit.changes.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.size, Matchers.equalTo(1))
+        Assert.assertThat(
+            codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.get(0)?.range,
+            Matchers.equalTo(range(7, 74, 7, 74))
+        )
+        Assert.assertThat(
+            codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.get(0)?.newText,
+            Matchers.equalTo(System.lineSeparator() + System.lineSeparator() + "    override fun someInterfaceMethod() { }")
+        )
+    }
+
+    @Test
+    fun `gets workspace edit for super class abstract methods when interface methods are implemented`() {
+        val diagnostic = Diagnostic(range(10, 1, 10, 25), "")
+        diagnostic.code = Either.forLeft("ABSTRACT_CLASS_MEMBER_NOT_IMPLEMENTED")
+        val codeActionParams = codeActionParams(file, 10, 1, 10, 25, listOf(diagnostic), listOf(CodeActionKind.QuickFix))
+
+        val codeActions = languageServer.textDocumentService.codeAction(codeActionParams).get()
+
+        Assert.assertThat(codeActions.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.kind, Matchers.equalTo(CodeActionKind.QuickFix))
+        Assert.assertThat(codeActions[0].right.diagnostics.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.diagnostics[0], Matchers.equalTo(diagnostic))
+        Assert.assertThat(codeActions[0].right.edit.changes.size, Matchers.equalTo(1))
+        Assert.assertThat(codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.size, Matchers.equalTo(1))
+        Assert.assertThat(
+            codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.get(0)?.range,
+            Matchers.equalTo(range(11, 43, 11, 43))
+        )
+        Assert.assertThat(
+            codeActions[0].right.edit.changes[codeActionParams.textDocument.uri]?.get(0)?.newText,
+            Matchers.equalTo(System.lineSeparator() + System.lineSeparator() + "    override fun someSuperMethod(someParameter: String): Int { }")
+        )
+    }
+}

--- a/server/src/test/resources/quickfixes/SomeInterface.kt
+++ b/server/src/test/resources/quickfixes/SomeInterface.kt
@@ -1,0 +1,5 @@
+package quickfixes
+
+interface SomeInterface {
+    fun someInterfaceMethod()
+}

--- a/server/src/test/resources/quickfixes/SomeSubclass.kt
+++ b/server/src/test/resources/quickfixes/SomeSubclass.kt
@@ -1,0 +1,12 @@
+package quickfixes
+
+class SomeSubclass : SomeSuperClass(), SomeInterface {
+}
+
+class SomeOtherSubclass : SomeSuperClass(), SomeInterface {
+    override fun someSuperMethod(someParameter: String): Int { return 1 }
+}
+
+class YetAnotherSubclass : SomeSuperClass(), SomeInterface {
+    override fun someInterfaceMethod() { }
+}

--- a/server/src/test/resources/quickfixes/SomeSuperClass.kt
+++ b/server/src/test/resources/quickfixes/SomeSuperClass.kt
@@ -1,0 +1,6 @@
+package quickfixes
+
+abstract class SomeSuperClass {
+
+    abstract fun someSuperMethod(someParameter: String): Int
+}


### PR DESCRIPTION
Somewhat related to https://github.com/fwcd/kotlin-language-server/issues/31 although I'm not sure whether that issue is about all overridable methods or just the ones that are required (i.e., abstract)

I refactored the code actions code a bit to introduce quick fixes (and potentially other kinds of code actions). I tried to keep things backwards compatible, so the Java to Kotlin conversion code action is still available where it should be I think