### PR TITLE
Send back prepare provider if supported by client

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -96,6 +96,10 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
             progressFactory = LanguageClientProgress.Factory(client)
         }
 
+        if (clientCapabilities?.textDocument?.rename?.prepareSupport ?: false) {
+            serverCapabilities.renameProvider = Either.forRight(RenameOptions(false))
+        }
+
         @Suppress("DEPRECATION")
         val folders = params.workspaceFolders?.takeIf { it.isNotEmpty() }
             ?: params.rootUri?.let(::WorkspaceFolder)?.let(::listOf)


### PR DESCRIPTION
Send back a RenameOptions object to client if the client capabilities
populate the prepareSupport field. See: https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#renameOptions
