### PR TITLE
Fix when is statement

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -244,6 +244,7 @@ private fun completableElement(file: CompiledFile, cursor: Int): KtElement? {
             // package x.y.?
             ?: el.findParent<KtPackageDirective>()
             // :?
+            ?: el as? KtUserType
             ?: el.parent as? KtTypeElement
             // .?
             ?: el as? KtQualifiedExpression

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -365,7 +365,7 @@ private fun completeMembers(file: CompiledFile, cursor: Int, receiverExpr: KtExp
             val extensions = extensionFunctions(lexicalScope).filter { isExtensionFor(receiverType, it) }
             descriptors = members + extensions
 
-            if (!isCompanionOfEnum(receiverType)) {
+            if (!isCompanionOfEnum(receiverType) && !isCompanionOfSealed(receiverType)) {
                 return descriptors
             }
         }
@@ -391,6 +391,16 @@ private fun isCompanionOfEnum(kotlinType: KotlinType): Boolean {
         return false
     }
     return DescriptorUtils.isEnumClass(classDescriptor?.containingDeclaration)
+}
+
+private fun isCompanionOfSealed(kotlinType: KotlinType): Boolean {
+    val classDescriptor = TypeUtils.getClassDescriptor(kotlinType)
+    val isCompanion = DescriptorUtils.isCompanionObject(classDescriptor)
+    if (!isCompanion) {
+        return false
+    }
+
+    return DescriptorUtils.isSealedClass(classDescriptor?.containingDeclaration)
 }
 
 private fun findPartialIdentifier(file: CompiledFile, cursor: Int): String {

--- a/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/Completions.kt
@@ -36,9 +36,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.lexer.KtKeywordToken
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.DescriptorUtils
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
-import org.jetbrains.kotlin.resolve.descriptorUtil.isExtension
-import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
+import org.jetbrains.kotlin.resolve.descriptorUtil.*
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter.Companion
 import org.jetbrains.kotlin.resolve.scopes.HierarchicalScope
@@ -63,12 +61,17 @@ fun completions(file: CompiledFile, cursor: Int, index: SymbolIndex, config: Com
     val partial = findPartialIdentifier(file, cursor)
     LOG.debug("Looking for completions that match '{}'", partial)
 
-    val (elementItems, isExhaustive, receiver) = elementCompletionItems(file, cursor, config, partial)
+    val (elementItems, element) = elementCompletionItems(file, cursor, config, partial)
     val elementItemList = elementItems.toList()
     val elementItemLabels = elementItemList.mapNotNull { it.label }.toSet()
+
+    val isExhaustive = element !is KtNameReferenceExpression
+                    && element !is KtTypeElement
+                    && element !is KtQualifiedExpression
+
     val items = (
         elementItemList.asSequence()
-        + (if (!isExhaustive) indexCompletionItems(file, cursor, receiver, index, partial).filter { it.label !in elementItemLabels } else emptySequence())
+        + (if (!isExhaustive) indexCompletionItems(file, cursor, element, index, partial).filter { it.label !in elementItemLabels } else emptySequence())
         + (if (elementItemList.isEmpty()) keywordCompletionItems(partial) else emptySequence())
     )
     val itemList = items
@@ -80,8 +83,13 @@ fun completions(file: CompiledFile, cursor: Int, index: SymbolIndex, config: Com
     return CompletionList(isIncomplete, itemList)
 }
 
+private fun getQueryNameFromExpression(receiver: KtExpression?, cursor: Int, file: CompiledFile): FqName? {
+    val receiverType = receiver?.let { expr -> file.scopeAtPoint(cursor)?.let { file.typeOfExpression(expr, it) } }
+    return receiverType?.constructor?.declarationDescriptor?.fqNameSafe
+}
+
 /** Finds completions in the global symbol index, for potentially unimported symbols. */
-private fun indexCompletionItems(file: CompiledFile, cursor: Int, receiver: KtExpression?, index: SymbolIndex, partial: String): Sequence<CompletionItem> {
+private fun indexCompletionItems(file: CompiledFile, cursor: Int, element: KtElement?, index: SymbolIndex, partial: String): Sequence<CompletionItem> {
     val parsedFile = file.parse
     val imports = parsedFile.importDirectives
     // TODO: Deal with alias imports
@@ -93,11 +101,23 @@ private fun indexCompletionItems(file: CompiledFile, cursor: Int, receiver: KtEx
     val importedNames = imports
         .mapNotNull { it.importedFqName?.shortName() }
         .toSet()
-    val receiverType = receiver?.let { expr -> file.scopeAtPoint(cursor)?.let { file.typeOfExpression(expr, it) } }
-    val receiverTypeFqName = receiverType?.constructor?.declarationDescriptor?.fqNameSafe
+
+    val queryName = when (element) {
+        is KtQualifiedExpression -> getQueryNameFromExpression(element.receiverExpression, element.receiverExpression.startOffset, file)
+        is KtSimpleNameExpression -> {
+            val receiver = element.getReceiverExpression()
+            when {
+                receiver != null -> getQueryNameFromExpression(receiver, receiver.startOffset, file)
+                else -> null
+            }
+        }
+        is KtUserType -> file.referenceAtPoint(element.qualifier?.startOffset ?: cursor)?.second?.fqNameSafe
+        is KtTypeElement -> file.referenceAtPoint(element.startOffsetInParent)?.second?.fqNameOrNull()
+        else -> null
+    }
 
     return index
-        .query(partial, receiverTypeFqName, limit = MAX_COMPLETION_ITEMS)
+        .query(partial, queryName, limit = MAX_COMPLETION_ITEMS)
         .asSequence()
         .filter { it.kind != Symbol.Kind.MODULE } // Ignore global module/package name completions for now, since they cannot be 'imported'
         .filter { it.fqName.shortName() !in importedNames && it.fqName.parent() !in wildcardPackages }
@@ -157,11 +177,11 @@ private fun keywordCompletionItems(partial: String): Sequence<CompletionItem> =
             kind = CompletionItemKind.Keyword
         } }
 
-data class ElementCompletionItems(val items: Sequence<CompletionItem>, val isExhaustive: Boolean, val receiver: KtExpression? = null)
+data class ElementCompletionItems(val items: Sequence<CompletionItem>, val element: KtElement? = null)
 
 /** Finds completions based on the element around the user's cursor. */
 private fun elementCompletionItems(file: CompiledFile, cursor: Int, config: CompletionConfiguration, partial: String): ElementCompletionItems {
-    val surroundingElement = completableElement(file, cursor) ?: return ElementCompletionItems(emptySequence(), isExhaustive = true)
+    val surroundingElement = completableElement(file, cursor) ?: return ElementCompletionItems(emptySequence())
     val completions = elementCompletions(file, cursor, surroundingElement)
 
     val matchesName = completions.filter { containsCharactersInOrder(name(it), partial, caseSensitive = false) }
@@ -169,12 +189,7 @@ private fun elementCompletionItems(file: CompiledFile, cursor: Int, config: Comp
         ?: matchesName.sortedBy { if (name(it).startsWith(partial)) 0 else 1 }
     val visible = sorted.filter(isVisible(file, cursor))
 
-    val isExhaustive = surroundingElement !is KtNameReferenceExpression
-                    && surroundingElement !is KtTypeElement
-                    && surroundingElement !is KtQualifiedExpression
-    val receiver = (surroundingElement as? KtQualifiedExpression)?.receiverExpression
-
-    return ElementCompletionItems(visible.map { completionItem(it, surroundingElement, file, config) }, isExhaustive, receiver)
+    return ElementCompletionItems(visible.map { completionItem(it, surroundingElement, file, config) }, surroundingElement)
 }
 
 private val callPattern = Regex("(.*)\\((?:\\$\\d+)?\\)(?:\\$0)?")

--- a/server/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/CompletionsTest.kt
@@ -265,6 +265,15 @@ class EnumWithCompanionObjectTest : SingleFileTestFixture("completions", "Enum.k
     }
 }
 
+class WhenTest : SingleFileTestFixture("completions", "When.kt") {
+    @Test fun `nested classes completion with is`() {
+        val completions = languageServer.textDocumentService.completion(completionParams(file, 9, 24)).get().right!!
+        val labels = completions.items.map { it.label }
+
+        assertThat(labels, hasItem("Test"))
+    }
+}
+
 class TrailingLambdaTest : SingleFileTestFixture("completions", "TrailingLambda.kt") {
     @Test fun `complete function with single lambda parameter`() {
         val completions = languageServer.textDocumentService.completion(completionParams(file, 6, 9)).get().right!!

--- a/server/src/test/resources/completions/When.kt
+++ b/server/src/test/resources/completions/When.kt
@@ -1,0 +1,11 @@
+sealed class SealedClass {
+    class Test: SealedClass() {}
+}
+
+fun sealedWhenFunc() {
+    val value: SealedClass = SealedClass.Test()
+
+    when (value) {
+        is SealedClass.
+    }
+}


### PR DESCRIPTION
Finding some of the completioons lacking when completing sealed classes in when statements, for instance:

```
sealed class Test {
  class Nested : Test() {}
}

fun test() {
  val example: Test = Test.Nested()
  when (example) {
    is Test._
  }
}
```

Won't complete when the cursor is on `_`. It seems like we're missing something whenever we parse those statements. I've attempted to add this completion

Unfortunately, I found that even with completion working I was running into two issues:

* Properties I expected to be present, weren't completing as I expected
* Indexed global symbols were completing when they probably shouldn't have been

In my project, this resulted in a bunch of junk completions that weren't relevant and missing several that were. I'm unsure of how to test for globally indexed completions, so I just went ahead and included additional descriptors for these classes and attempted to fix the queries for global symbols.

Since I don't terribly know what I'm doing with the completion system, it's likely I broke something else or fixed this incorrectly. It doesn't help that a fresh clone has 3 failing tests on my machine, so I'm not entirely confident in the first place :P

Feedback welcome