### PR TITLE
Fix code formatting with `ktfmt` (fixes #304)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,12 @@
                 "kind": "build",
                 "isDefault": true
             }
+        },
+        {
+            "label": "Format code with ktfmt",
+            "type": "shell",
+            "command": "gradle ktfmtFormat",
+            "problemMatcher": []
         }
     ]
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'application'
     id 'com.github.jk1.tcdeps' version '1.2'
     id 'com.jaredsburrows.license' version '0.8.42'
+    id 'com.ncorti.ktfmt.gradle' version '0.7.0'
 }
 
 version = projectVersion
@@ -137,6 +138,13 @@ test {
 distZip {
     archiveFileName = "${project.name}.zip"
 }
+
+ktfmt {
+    // KotlinLang style - 4 space indentation - From kotlinlang.org/docs/coding-conventions.html
+    kotlinLangStyle()
+}
+
+build.dependsOn ktfmtCheck
 
 installDist.finalizedBy fixFilePermissions
 build.finalizedBy installDist

--- a/server/src/main/kotlin/org/javacs/kt/formatting/Formatter.kt
+++ b/server/src/main/kotlin/org/javacs/kt/formatting/Formatter.kt
@@ -8,7 +8,9 @@ fun formatKotlinCode(
     code: String,
     options: FormattingOptions = FormattingOptions(4, true)
 ): String = Formatter.format(KtfmtOptions(
+    // If option.tabSize is 2 or 4, the generated KtfmtOptions instance concides with one of the two presets in
+    // https://github.com/facebookincubator/ktfmt/blob/d4718f643abd0999ba502caf5062c98a3218e88d/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt#L45-L50
     style = KtfmtOptions.Style.GOOGLE,
     blockIndent = options.tabSize,
-    continuationIndent = 2 * options.tabSize
+    continuationIndent = options.tabSize
 ), code)

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'maven-publish'
+    id 'com.ncorti.ktfmt.gradle' version '0.7.0'
 }
 
 version = projectVersion
@@ -16,3 +17,10 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 	testImplementation 'junit:junit:4.11'
 }
+
+ktfmt {
+    // KotlinLang style - 4 space indentation - From kotlinlang.org/docs/coding-conventions.html
+    kotlinLangStyle()
+}
+
+build.dependsOn ktfmtCheck


### PR DESCRIPTION
Following previous discussion in https://github.com/fwcd/kotlin-language-server/issues/303#issuecomment-1045989516, this PR is an attempt to resolve https://github.com/fwcd/kotlin-language-server/issues/304:

- Fix the existing code formatting with `gradle ktfmtFormat` using the [official style configuration](https://github.com/facebookincubator/ktfmt/blob/d4718f643abd0999ba502caf5062c98a3218e88d/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt#L48-L50):
  ```kt
  val KOTLINLANG_FORMAT = FormattingOptions(style = GOOGLE, blockIndent = 4, continuationIndent = 4)
  ```
- Adjust default KLS formatting option to match `KOTLINLANG_FORMAT`:
  https://github.com/fwcd/kotlin-language-server/blob/55f58e807cb324ece9fd86eb450c21a6e63acfa2/server/src/main/kotlin/org/javacs/kt/formatting/Formatter.kt#L15-L19
- Make `gradle build` depend on `gradle ktfmtCheck`.
- Add corresponding VSCode formatting task.

## Questions

- [ ] Why do we need to vendor `ktfmt` for this project?
- [ ] CI check should have been triggered on PR?
