### PR TITLE
Check if gradlew is executable

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/GradleClassPathResolver.kt
@@ -61,7 +61,7 @@ private fun gradleScriptToTempFile(scriptName: String, deleteOnExit: Boolean = f
 private fun getGradleCommand(workspace: Path): Path {
     val wrapperName = if (isOSWindows()) "gradlew.bat" else "gradlew"
     val wrapper = workspace.resolve(wrapperName).toAbsolutePath()
-    if (Files.exists(wrapper)) {
+    if (Files.isExecutable(wrapper)) {
         return wrapper
     } else {
         return workspace.parent?.let(::getGradleCommand)


### PR DESCRIPTION
There are rare instances, where there is a non-executable "gradlew" next to a build script. In this case the language server will crash when trying to execute "gradlew".
The happens for example when using an openapi generator as this will place a "build.gradle" and a non-executable "gradlew" in the "build/generated" directory as helper files.