### PR TITLE
Resolves an infinite loop and/or memory leak

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=1.3.0
-kotlinVersion=1.5.20
-exposedVersion=0.32.1
+kotlinVersion=1.6.10
+exposedVersion=0.37.3
 lsp4jVersion=0.12.0
-javaVersion=11
+javaVersion=8


### PR DESCRIPTION
Recently, on Neovim's LSP, I noticed that we were indexing seemingly indefinitely. This resulted in consuming all of the RAM on my laptop and freezing the whole thing!  I'm not entire sure what was causing it, but I noticed that bumping our dependencies seemed to solve the problem

This did result in some build errors regarding mixed java version usage, so I dropped our `javaVersion` to 8. If that's unacceptable, I can look for other solutions