### PR TITLE
Implemented maven wrapper (mvnw) support

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
@@ -2,6 +2,7 @@ package org.javacs.kt.classpath
 
 import org.javacs.kt.LOG
 import org.javacs.kt.util.findCommandOnPath
+import org.javacs.kt.util.findProjectCommandWithName
 import org.javacs.kt.util.execAndReadStdoutAndStderr
 import java.nio.file.Path
 import java.nio.file.Files
@@ -103,14 +104,14 @@ private fun mavenJarName(a: Artifact, source: Boolean) =
 
 private fun generateMavenDependencyList(pom: Path): Path {
     val mavenOutput = Files.createTempFile("deps", ".txt")
-    val command = "$mvnCommand dependency:list -DincludeScope=test -DoutputFile=$mavenOutput -Dstyle.color=never"
+    val command = "${mvnCommand(pom)} dependency:list -DincludeScope=test -DoutputFile=$mavenOutput -Dstyle.color=never"
     runCommand(pom, command)
     return mavenOutput
 }
 
 private fun generateMavenDependencySourcesList(pom: Path): Path {
     val mavenOutput = Files.createTempFile("sources", ".txt")
-    val command = "$mvnCommand dependency:sources -DincludeScope=test -DoutputFile=$mavenOutput -Dstyle.color=never"
+    val command = "${mvnCommand(pom)} dependency:sources -DincludeScope=test -DoutputFile=$mavenOutput -Dstyle.color=never"
     runCommand(pom, command)
     return mavenOutput
 }
@@ -125,8 +126,14 @@ private fun runCommand(pom: Path, command: String) {
     }
 }
 
-private val mvnCommand: Path by lazy {
-    requireNotNull(findCommandOnPath("mvn")) { "Unable to find the 'mvn' command" }
+private val mvnCommandFromPath: Path? by lazy {
+    findCommandOnPath("mvn")
+}
+
+private fun mvnCommand(pom : Path) : Path {
+	return requireNotNull(mvnCommandFromPath ?: findProjectCommandWithName("mvnw", pom)?.also {
+		LOG.info("Using mvn wrapper (mvnw) in place of mvn command")
+	}) { "Unable to find the 'mvn' command or suitable wrapper" }
 }
 
 fun parseMavenArtifact(rawArtifact: String, version: String? = null): Artifact {

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
@@ -130,10 +130,10 @@ private val mvnCommandFromPath: Path? by lazy {
     findCommandOnPath("mvn")
 }
 
-private fun mvnCommand(pom : Path) : Path {
-	return requireNotNull(mvnCommandFromPath ?: findProjectCommandWithName("mvnw", pom)?.also {
-		LOG.info("Using mvn wrapper (mvnw) in place of mvn command")
-	}) { "Unable to find the 'mvn' command or suitable wrapper" }
+private fun mvnCommand(pom: Path): Path {
+    return requireNotNull(mvnCommandFromPath ?: findProjectCommandWithName("mvnw", pom)?.also {
+        LOG.info("Using mvn wrapper (mvnw) in place of mvn command")
+    }) { "Unable to find the 'mvn' command or suitable wrapper" }
 }
 
 fun parseMavenArtifact(rawArtifact: String, version: String? = null): Artifact {

--- a/shared/src/main/kotlin/org/javacs/kt/util/ShellPathUtils.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/util/ShellPathUtils.kt
@@ -34,18 +34,16 @@ private fun findExecutableOnPath(fileName: String): Path? {
     return null
 }
 
-fun findProjectCommandWithName(name : String, projectFile : Path) : Path? {
-	if(isOSWindows()) {
-		return findFileRelativeToProjectFile("$name.cmd", projectFile)
-	} else {
-		return findFileRelativeToProjectFile(name, projectFile)
-	}
-}
+fun findProjectCommandWithName(name: String, projectFile: Path): Path? =
+    if (isOSWindows()) {
+        findFileRelativeToProjectFile("$name.cmd", projectFile)
+    } else {
+        findFileRelativeToProjectFile(name, projectFile)
+    }
 
-private fun findFileRelativeToProjectFile(name : String, projectFile : Path) : Path? {
-	return projectFile.resolveSibling(name).toFile().takeIf { file ->
-		file.isFile && file.canExecute()
-	}?.let { file ->
-		Paths.get(file.absolutePath)
-	}
-}
+private fun findFileRelativeToProjectFile(name: String, projectFile: Path): Path? =
+    projectFile.resolveSibling(name).toFile().takeIf { file ->
+        file.isFile && file.canExecute()
+    }?.let { file ->
+        Paths.get(file.absolutePath)
+    }

--- a/shared/src/main/kotlin/org/javacs/kt/util/ShellPathUtils.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/util/ShellPathUtils.kt
@@ -33,3 +33,19 @@ private fun findExecutableOnPath(fileName: String): Path? {
 
     return null
 }
+
+fun findProjectCommandWithName(name : String, projectFile : Path) : Path? {
+	if(isOSWindows()) {
+		return findFileRelativeToProjectFile("$name.cmd", projectFile)
+	} else {
+		return findFileRelativeToProjectFile(name, projectFile)
+	}
+}
+
+private fun findFileRelativeToProjectFile(name : String, projectFile : Path) : Path? {
+	return projectFile.resolveSibling(name).toFile().takeIf { file ->
+		file.isFile && file.canExecute()
+	}?.let { file ->
+		Paths.get(file.absolutePath)
+	}
+}


### PR DESCRIPTION
Makes the language server work in environments that only have the Maven wrapper. Only requirement is that the mvnw file (or mvnw.cmd on Windows) is executable, and in the same directory as the pom.xml file (which it always is if present). Server still uses mvn binary by default if that one is found, but fallbacks to trying mvnw if it's not.

The `mvnCommand` function might look a bit messy. Originally it did not have the also-statement, but I thought it would be useful for it to be logged if the Maven wrapper was used. If the `findProjectCommandWithName("mvnw", pom)` call is non-null, and the also-block is called, it will be used. Let me know if you would prefer this in a cleaner way, or if there are any issues I've missed.

Fixes #285 