### PR TITLE
add LSIF indexing & uploading to Sourcegraph workflow

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -1,0 +1,23 @@
+name: Sourcegraph LSIF
+on:
+  push:
+  pull_request:
+jobs:
+  lsif:
+    runs-on: ubuntu-latest
+    name: "Upload LSIF"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: coursier/cache-action@v6.3
+      - uses: coursier/setup-action@v1.1.2
+        with:
+          jvm: adopt:11
+          apps: lsif-java
+      - name: Generate LSIF
+        run: lsif-java index
+      - name: Upload LSIF data
+        uses: sourcegraph/lsif-upload-action@master
+        with:
+          endpoint: https://sourcegraph.com
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dump.lsif


### PR DESCRIPTION
Adds LSIF indexing workflow with [Kotlin SemanticDB](https://github.com/sourcegraph/lsif-kotlin) compiler plugin via the [lsif-java](https://github.com/sourcegraph/lsif-java) cli tool. Resulting LSIF file is uploaded to [Sourcegraph](https://sourcegraph.com) for "precise code intelligence" navigation. 

This will help us get more in-the-wild testing of the Kotlin plugin (please feel free to report any and all issues :slightly_smiling_face:), and hopefully you find it useful too when reviewing PRs.