### PR TITLE
"Add missing import" quick fix Code Action

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -93,7 +93,7 @@ class KotlinTextDocumentService(
 
     override fun codeAction(params: CodeActionParams): CompletableFuture<List<Either<Command, CodeAction>>> = async.compute {
         val (file, _) = recover(params.textDocument.uri, params.range.start, Recompile.NEVER)
-        codeActions(file, params.range, params.context)
+        codeActions(file, sp.index, params.range, params.context)
     }
 
     override fun hover(position: HoverParams): CompletableFuture<Hover?> = async.compute {

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt
@@ -25,7 +25,7 @@ class AddMissingImportsQuickFix: QuickFix {
 
             getImportAlternatives(symbolName, file.parse, index).map { (importStr, edit) ->
                 val codeAction = CodeAction()
-                codeAction.title = "import ${importStr}"
+                codeAction.title = "Import ${importStr}"
                 codeAction.kind = CodeActionKind.QuickFix
                 codeAction.diagnostics = listOf(diagnostic)
                 codeAction.edit = WorkspaceEdit(mapOf(uri to listOf(edit)))
@@ -42,15 +42,15 @@ class AddMissingImportsQuickFix: QuickFix {
 
     private fun getImportAlternatives(symbolName: String, file: KtFile, index: SymbolIndex): List<Pair<String, TextEdit>> {
         // wildcard matcher to empty string, because we only want to match exactly the symbol itself, not anything extra
-        val queryResult = index.query(symbolName, wildcardMatcher = "")
+        val queryResult = index.query(symbolName, suffix = "")
         
         return queryResult
-            .filter { it.kind != Symbol.Kind.MODULE }
             .filter {
+                it.kind != Symbol.Kind.MODULE &&
                 // TODO: Visibility checker should be less liberal
-                it.visibility == Symbol.Visibility.PUBLIC
-                || it.visibility == Symbol.Visibility.PROTECTED
-                || it.visibility == Symbol.Visibility.INTERNAL
+                (it.visibility == Symbol.Visibility.PUBLIC
+                 || it.visibility == Symbol.Visibility.PROTECTED
+                 || it.visibility == Symbol.Visibility.INTERNAL)
             }
             .map {
                 Pair(it.fqName.toString(), getImportTextEditEntry(file, it.fqName))

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/AddMissingImportsQuickFix.kt
@@ -1,0 +1,59 @@
+package org.javacs.kt.codeaction.quickfix
+
+import org.eclipse.lsp4j.*
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.jetbrains.kotlin.psi.KtFile
+import org.javacs.kt.CompiledFile
+import org.javacs.kt.LOG
+import org.javacs.kt.index.SymbolIndex
+import org.javacs.kt.index.Symbol
+import org.javacs.kt.position.offset
+import org.javacs.kt.util.toPath
+import org.javacs.kt.codeaction.quickfix.diagnosticMatch
+import org.javacs.kt.imports.getImportTextEditEntry
+
+class AddMissingImportsQuickFix: QuickFix {
+    override fun compute(file: CompiledFile, index: SymbolIndex, range: Range, diagnostics: List<Diagnostic>): List<Either<Command, CodeAction>> {
+        val uri = file.parse.toPath().toUri().toString()
+        val unresolvedReferences = getUnresolvedReferencesFromDiagnostics(diagnostics) 
+        
+        return unresolvedReferences.flatMap { diagnostic ->
+            val diagnosticRange = diagnostic.range
+            val startCursor = offset(file.content, diagnosticRange.start)
+            val endCursor = offset(file.content, diagnosticRange.end)
+            val symbolName = file.content.substring(startCursor, endCursor)
+
+            getImportAlternatives(symbolName, file.parse, index).map { (importStr, edit) ->
+                val codeAction = CodeAction()
+                codeAction.title = "import ${importStr}"
+                codeAction.kind = CodeActionKind.QuickFix
+                codeAction.diagnostics = listOf(diagnostic)
+                codeAction.edit = WorkspaceEdit(mapOf(uri to listOf(edit)))
+                
+                Either.forRight(codeAction)
+            }
+        }
+    }
+
+    private fun getUnresolvedReferencesFromDiagnostics(diagnostics: List<Diagnostic>): List<Diagnostic> =
+        diagnostics.filter {
+            "UNRESOLVED_REFERENCE" == it.code.left.trim()
+        }
+
+    private fun getImportAlternatives(symbolName: String, file: KtFile, index: SymbolIndex): List<Pair<String, TextEdit>> {
+        // wildcard matcher to empty string, because we only want to match exactly the symbol itself, not anything extra
+        val queryResult = index.query(symbolName, wildcardMatcher = "")
+        
+        return queryResult
+            .filter { it.kind != Symbol.Kind.MODULE }
+            .filter {
+                // TODO: Visibility checker should be less liberal
+                it.visibility == Symbol.Visibility.PUBLIC
+                || it.visibility == Symbol.Visibility.PROTECTED
+                || it.visibility == Symbol.Visibility.INTERNAL
+            }
+            .map {
+                Pair(it.fqName.toString(), getImportTextEditEntry(file, it.fqName))
+            }
+    }
+}

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractFunctionsQuickFix.kt
@@ -3,6 +3,7 @@ package org.javacs.kt.codeaction.quickfix
 import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.javacs.kt.CompiledFile
+import org.javacs.kt.index.SymbolIndex
 import org.javacs.kt.position.offset
 import org.javacs.kt.position.position
 import org.javacs.kt.util.toPath
@@ -20,7 +21,7 @@ import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
 private const val DEFAULT_TAB_SIZE = 4
 
 class ImplementAbstractFunctionsQuickFix : QuickFix {
-    override fun compute(file: CompiledFile, range: Range, diagnostics: List<Diagnostic>): Either<Command, CodeAction>? {
+    override fun compute(file: CompiledFile, index: SymbolIndex, range: Range, diagnostics: List<Diagnostic>): List<Either<Command, CodeAction>> {
         val diagnostic = findDiagnosticMatch(diagnostics, range)
 
         val startCursor = offset(file.content, range.start)
@@ -52,10 +53,10 @@ class ImplementAbstractFunctionsQuickFix : QuickFix {
                 codeAction.kind = CodeActionKind.QuickFix
                 codeAction.title = "Implement abstract functions"
                 codeAction.diagnostics = listOf(diagnostic)
-                return Either.forRight(codeAction)
+                return listOf(Either.forRight(codeAction))
             }
         }
-        return null
+        return listOf()
     }
 }
 

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt
@@ -6,12 +6,13 @@ import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.javacs.kt.CompiledFile
+import org.javacs.kt.index.SymbolIndex
 import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
 import org.jetbrains.kotlin.diagnostics.Diagnostic as KotlinDiagnostic
 
 interface QuickFix {
-    // Computes the quickfix. Return null if the quickfix is not valid.
-    fun compute(file: CompiledFile, range: Range, diagnostics: List<Diagnostic>): Either<Command, CodeAction>?
+    // Computes the quickfix. Return empty list if the quickfix is not valid or no alternatives exist.
+    fun compute(file: CompiledFile, index: SymbolIndex, range: Range, diagnostics: List<Diagnostic>): List<Either<Command, CodeAction>>
 }
 
 fun diagnosticMatch(diagnostic: Diagnostic, range: Range, diagnosticTypes: HashSet<String>): Boolean =

--- a/server/src/main/kotlin/org/javacs/kt/imports/Imports.kt
+++ b/server/src/main/kotlin/org/javacs/kt/imports/Imports.kt
@@ -1,0 +1,38 @@
+package org.javacs.kt.imports
+
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextEdit
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.*
+import org.javacs.kt.position.location
+
+fun getImportTextEditEntry(parsedFile: KtFile, fqName: FqName): TextEdit {
+    val imports = parsedFile.importDirectives
+    val importedNames = imports
+        .mapNotNull { it.importedFqName?.shortName() }
+        .toSet()
+    
+    val pos = findImportInsertionPosition(parsedFile, fqName)
+    val prefix = if (importedNames.isEmpty()) "\n\n" else "\n"
+    return TextEdit(Range(pos, pos), "${prefix}import ${fqName}")
+}
+
+/** Finds a good insertion position for a new import of the given fully-qualified name. */
+private fun findImportInsertionPosition(parsedFile: KtFile, fqName: FqName): Position =
+    (closestImport(parsedFile.importDirectives, fqName) as? KtElement ?: parsedFile.packageDirective as? KtElement)
+        ?.let(::location)
+        ?.range
+        ?.end
+        ?: Position(0, 0)
+
+// TODO: Lexicographic insertion
+private fun closestImport(imports: List<KtImportDirective>, fqName: FqName): KtImportDirective? =
+    imports
+        .asReversed()
+        .maxByOrNull { it.importedFqName?.let { matchingPrefixLength(it, fqName) } ?: 0 }
+
+private fun matchingPrefixLength(left: FqName, right: FqName): Int =
+    left.pathSegments().asSequence().zip(right.pathSegments().asSequence())
+        .takeWhile { it.first == it.second }
+        .count()

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -177,11 +177,11 @@ class SymbolIndex {
         fqName.toString().length <= MAX_FQNAME_LENGTH
             && fqName.shortName().toString().length <= MAX_SHORT_NAME_LENGTH
 
-    fun query(prefix: String, receiverType: FqName? = null, limit: Int = 20): List<Symbol> = transaction(db) {
+    fun query(prefix: String, receiverType: FqName? = null, limit: Int = 20, wildcardMatcher: String = "%"): List<Symbol> = transaction(db) {
         // TODO: Extension completion currently only works if the receiver matches exactly,
         //       ideally this should work with subtypes as well
         SymbolEntity.find {
-            (Symbols.shortName like "$prefix%") and (Symbols.extensionReceiverType eq receiverType?.toString())
+            (Symbols.shortName like "$prefix$wildcardMatcher") and (Symbols.extensionReceiverType eq receiverType?.toString())
         }.limit(limit)
             .map { Symbol(
                 fqName = FqName(it.fqName),

--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -177,11 +177,11 @@ class SymbolIndex {
         fqName.toString().length <= MAX_FQNAME_LENGTH
             && fqName.shortName().toString().length <= MAX_SHORT_NAME_LENGTH
 
-    fun query(prefix: String, receiverType: FqName? = null, limit: Int = 20, wildcardMatcher: String = "%"): List<Symbol> = transaction(db) {
+    fun query(prefix: String, receiverType: FqName? = null, limit: Int = 20, suffix: String = "%"): List<Symbol> = transaction(db) {
         // TODO: Extension completion currently only works if the receiver matches exactly,
         //       ideally this should work with subtypes as well
         SymbolEntity.find {
-            (Symbols.shortName like "$prefix$wildcardMatcher") and (Symbols.extensionReceiverType eq receiverType?.toString())
+            (Symbols.shortName like "$prefix$suffix") and (Symbols.extensionReceiverType eq receiverType?.toString())
         }.limit(limit)
             .map { Symbol(
                 fqName = FqName(it.fqName),


### PR DESCRIPTION
Implements Add missing import code action. If I'm not misinterpreting the issue, it is what #302 is requesting. it was something I was really wanting myself. To be honest, I've been using the completion functionality to get my imports in order sometimes 😆 

Emacs screenshots incoming. One line (using lsp-ui, code action marked in yellow):
<img width="704" alt="Screenshot 2022-04-02 at 15 37 38" src="https://user-images.githubusercontent.com/5732795/161385940-60d9b3a9-35b8-4da9-a855-05bcd94a3fc6.png">

Marking entire file, then run lsp-execute-code-action:
<img width="704" alt="Screenshot 2022-04-02 at 15 38 11" src="https://user-images.githubusercontent.com/5732795/161385970-ce4c7ddf-aaea-42a3-9860-607b794f85c6.png">

In VSCode, I was not able to screenshot the code-action itself (Command-Space interrupted the quikfix), but as shown in the screenshot here, quickfixes are available:
<img width="976" alt="Screenshot 2022-04-02 at 15 39 51" src="https://user-images.githubusercontent.com/5732795/161386039-20823598-2845-46b4-a53a-bd2c93903850.png">
(it will show the same import as the Emacs screenshots above)


Did a couple of small rewrites to make this new functionality more clean. The most important ones are:
- Extracted the TextEdit creation of imports to its own function (and package) for use with this new quick fix, as well as the completions that currently uses it. 
- Rewrite the interface for QuickFix to return a list instead of possibly null. Missing import classnames/functions can come from different packages, but have the same name, which means that it can be more than one alternative. Also, if you mark the entire file in Emacs, you can then get import alternatives from the entire file (as diagnostics for the entire marked area is sent). This applies to marked larger regions of code as well. Usually I would avoid rewriting interfaces, but I made an exception to my rule due to this only being used one place.
- Rewrite the interface for QuickFix to take the symbol index as a parameter. This is needed to query for possible alternatives for the missing imports. Maybe there are also future quick fixes that can use the index for something?
- Added QuickFix to requestedKind in CodeActions when only is null. Emacs (or at least on my machine) does not seem to send the only-field. QuickFix seems to be a reasonable part of the defaults.
- Made the %-symbol in the like-statement toggleable when doing a query of the symbol-index. So far I only set it to the empty string to match exactly without wildcards, but it might have other uses in the future. Let me know if you have a more elegant solution to this problem 🙂 


Let me know if there is any formatting issues, or other issues. The editorconfig in Emacs is not perfect atm, but have tried to follow the few things you mentioned in my last PR 🙂 


EDIT: Sorry for being slow. Forgot the actual quick fix class the first time. This is what you get for coding in the weekend after a hectic week at work 😆 