### PR TITLE
Folder sync progress notifications never report that they are done ("Refreshing source path" always present in Emacs modeline)

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -108,7 +108,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
 
         folders.forEachIndexed { i, folder ->
             LOG.info("Adding workspace folder {}", folder.name)
-            val progressPrefix = "[${i + 1}/${folders.size}] ${folder.name}"
+            val progressPrefix = "[${i + 1}/${folders.size}] ${folder.name ?: ""}"
             val progressPercent = (100 * i) / folders.size
 
             progress?.update("$progressPrefix: Updating source path", progressPercent)
@@ -122,6 +122,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
                 sourcePath.refresh()
             }
         }
+		progress?.close()
 
         textDocuments.lintAll()
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -122,7 +122,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
                 sourcePath.refresh()
             }
         }
-		progress?.close()
+        progress?.close()
 
         textDocuments.lintAll()
 


### PR DESCRIPTION
The folder sync tasks reports that they are in-progress, but not done. This causes some editors like Emacs using lsp-mode to always display them. No matter how long I wait, "Refreshing source path" will always be there, like you can see in my modeline here:

(ignore that the date-part of my modeline is crushed into the notifications. I have been too lazy to fix it)
![Screenshot 2022-04-13 at 13 58 16](https://user-images.githubusercontent.com/5732795/163177272-604acb31-3f61-4408-afc9-c3e08836fe2d.png)

Example where indexing is happening at the same time:
![Screenshot 2022-04-13 at 13 58 52](https://user-images.githubusercontent.com/5732795/163177337-978a017f-4ebd-4a05-9a8d-d702dc56873e.png)


You will also notice that `folder.name` part of the message is null, which can be a bit confusing. I added Elvis here to take care of business and make it an empty string in these cases 😄 


Have to admit I've been experiencing these issues for quite a long time, and have probably been lazy for not looking into it. Yesterday I had the epiphany that it might be very confusing to new people who start to use it, and I don't want more people being scared away from Emacs 😆  I didn't experience them in VSCode, but I suspect that they might be present in some other editor.