### PR TITLE
Allow specifying a gradle JDK in settings

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -14,7 +14,7 @@ import java.nio.file.Path
  * Manages the class path (compiled JARs, etc), the Java source path
  * and the compiler. Note that Kotlin sources are stored in SourcePath.
  */
-class CompilerClassPath(private val config: CompilerConfiguration) : Closeable {
+class CompilerClassPath(private val config: CompilerConfiguration, private val gradleHome: StringBuilder) : Closeable {
     val workspaceRoots = mutableSetOf<Path>()
 
     private val javaSourcePath = mutableSetOf<Path>()
@@ -39,7 +39,7 @@ class CompilerClassPath(private val config: CompilerConfiguration) : Closeable {
         updateJavaSourcePath: Boolean = true
     ): Boolean {
         // TODO: Fetch class path and build script class path concurrently (and asynchronously)
-        val resolver = defaultClassPathResolver(workspaceRoots)
+        val resolver = defaultClassPathResolver(workspaceRoots, gradleHome)
         var refreshCompiler = updateJavaSourcePath
 
         if (updateClassPath) {

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -35,10 +35,16 @@ public data class ExternalSourcesConfiguration(
     var autoConvertToKotlin: Boolean = false
 )
 
+public data class GradleConfiguration(
+    /** The JDK to use to launch gradle, the default is JAVA_HOME. */
+    val home: StringBuilder = StringBuilder("default")
+)
+
 public data class Configuration(
     val compiler: CompilerConfiguration = CompilerConfiguration(),
     val completion: CompletionConfiguration = CompletionConfiguration(),
     val linting: LintingConfiguration = LintingConfiguration(),
     var indexing: IndexingConfiguration = IndexingConfiguration(),
-    val externalSources: ExternalSourcesConfiguration = ExternalSourcesConfiguration()
+    val externalSources: ExternalSourcesConfiguration = ExternalSourcesConfiguration(),
+    val gradle: GradleConfiguration = GradleConfiguration()
 )

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -30,7 +30,7 @@ class KotlinWorkspaceService(
 ) : WorkspaceService, LanguageClientAware {
     private val gson = Gson()
     private var languageClient: LanguageClient? = null
- 
+
     override fun connect(client: LanguageClient): Unit {
         languageClient = client
     }
@@ -137,6 +137,10 @@ class KotlinWorkspaceService(
                 val externalSources = config.externalSources
                 get("useKlsScheme")?.asBoolean?.let { externalSources.useKlsScheme = it }
                 get("autoConvertToKotlin")?.asBoolean?.let { externalSources.autoConvertToKotlin = it }
+            }
+
+            get("gradle")?.asJsonObject?.apply {
+                get("home")?.asString?.let { config.gradle.home.clear().append(it) }
             }
         }
 

--- a/server/src/test/kotlin/org/javacs/kt/ClassPathTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/ClassPathTest.kt
@@ -21,7 +21,7 @@ class ClassPathTest {
 
         assertTrue(Files.exists(buildFile))
 
-        val resolvers = defaultClassPathResolver(listOf(workspaceRoot))
+        val resolvers = defaultClassPathResolver(listOf(workspaceRoot), StringBuilder("default"))
         print(resolvers)
         val classPath = resolvers.classpathOrEmpty.map { it.toString() }
 

--- a/server/src/test/kotlin/org/javacs/kt/CompiledFileTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/CompiledFileTest.kt
@@ -29,7 +29,7 @@ class CompiledFileTest {
         val file = testResourcesRoot().resolve("compiledFile/CompiledFileExample.kt")
         val content = Files.readAllLines(file).joinToString("\n")
         val parse = compiler.createKtFile(content, file)
-        val classPath = CompilerClassPath(CompilerConfiguration())
+        val classPath = CompilerClassPath(CompilerConfiguration(), StringBuilder("default"))
         val sourcePath = listOf(parse)
         val (context, container) = compiler.compileKtFiles(sourcePath, sourcePath)
         CompiledFile(content, parse, context, container, sourcePath, classPath)

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
@@ -119,7 +119,7 @@ private fun generateMavenDependencySourcesList(pom: Path): Path {
 private fun runCommand(pom: Path, command: List<String>) {
     val workingDirectory = pom.toAbsolutePath().parent
     LOG.info("Run {} in {}", command, workingDirectory)
-    val (result, errors) = execAndReadStdoutAndStderr(command, workingDirectory)
+    val (result, errors) = execAndReadStdoutAndStderr(command, workingDirectory, null)
     LOG.debug(result)
     if ("BUILD FAILURE" in errors) {
         LOG.warn("Maven task failed: {}", errors.lines().firstOrNull())

--- a/shared/src/main/kotlin/org/javacs/kt/util/Utils.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/util/Utils.kt
@@ -12,8 +12,10 @@ fun execAndReadStdout(shellCommand: List<String>, directory: Path): String {
     return stdout.bufferedReader().use { it.readText() }
 }
 
-fun execAndReadStdoutAndStderr(shellCommand: List<String>, directory: Path): Pair<String, String> {
-    val process = ProcessBuilder(shellCommand).directory(directory.toFile()).start()
+fun execAndReadStdoutAndStderr(shellCommand: List<String>, directory: Path, gradleHome: String?): Pair<String, String> {
+    val process = ProcessBuilder(shellCommand).directory(directory.toFile()).apply {
+        environment()["JAVA_HOME"] = gradleHome?.takeIf { it != "default" } ?: return@apply
+    }.start()
     val stdout = process.inputStream
     val stderr = process.errorStream
     var output = ""


### PR DESCRIPTION
This is helpful as the kls init script uses JAVA_HOME to determine what JDK to use for launching itself, so someone can't use that same variable to control gradle without ignoring the script altogether and redoing its logic elsewhere