### PR TITLE
Experimental resolution of dependencies in Kotlin multiplatform projects (Gradle)

### DIFF
--- a/shared/src/main/resources/projectClassPathFinder.gradle
+++ b/shared/src/main/resources/projectClassPathFinder.gradle
@@ -58,6 +58,23 @@ allprojects { project ->
                     }
                 }
             }
+
+
+            // handle kotlin multiplatform style dependencies if any
+            def kotlinExtension = project.extensions.findByName("kotlin")
+            if(kotlinExtension) {
+                def kotlinSourceSets = kotlinExtension.sourceSets
+
+                // Print the list of all dependencies jar files.
+                kotlinSourceSets.forEach {
+                    // fetch the jar files from the current source set config (identified by their displayname, e.g, backendMain)
+                    def dependencyLocations = configurations["${it.displayName}ImplementationDependenciesMetadata"].files
+
+                    dependencyLocations.each {
+                        System.out.println "kotlin-lsp-gradle $it"
+                    }
+                }
+            }
         }
     }
 

--- a/shared/src/main/resources/projectClassPathFinder.gradle
+++ b/shared/src/main/resources/projectClassPathFinder.gradle
@@ -62,15 +62,13 @@ allprojects { project ->
 
             // handle kotlin multiplatform style dependencies if any
             def kotlinExtension = project.extensions.findByName("kotlin")
-            if(kotlinExtension) {
+            if(kotlinExtension && kotlinExtension.hasProperty("targets")) {
                 def kotlinSourceSets = kotlinExtension.sourceSets
 
                 // Print the list of all dependencies jar files.
-                kotlinSourceSets.forEach {
-                    // fetch the jar files from the current source set config (identified by their displayname, e.g, backendMain)
-                    def dependencyLocations = configurations["${it.displayName}ImplementationDependenciesMetadata"].files
-
-                    dependencyLocations.each {
+                kotlinExtension.targets.names.each {
+                    def classpath = configurations["${it}CompileClasspath"]
+                    classpath.files.each {
                         System.out.println "kotlin-lsp-gradle $it"
                     }
                 }


### PR DESCRIPTION
Implements basic dependency resolution for Kotlin multiplatform projects using Gradle, though a bit flawed (see below). Multiplatform projects have a bit of a different structure than what we are used to in regular projects. In one folder (and build.gradle file) there can be several targets. You can read more on that [here](https://kotlinlang.org/docs/multiplatform-discover-project.html).


Have tried a few different projects, mainly (found in #376):
https://github.com/ktorio/ktor-samples/tree/main/chat


Seem to work pretty good, but I see one possible issue:
- The language server does not separate between the different targets, so it will just resolve the dependencies for all of them. That means a frontend target will get completions with dependencies of the backend target and so on. This is because the language server works on a gradle module basis, and not on a Kotlin multiplatform target basis. This would have to be rewritten to work properly, and I think this might be a lot of work. I still think some flawed support is way better than people getting tons of errors. Now they can at least work with external dependencies in those projects (no errors, and completions work) 🙂 Feel free to disagree. 