### PR TITLE
General override member(s) functionality

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensionService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensionService.kt
@@ -4,6 +4,8 @@ import org.eclipse.lsp4j.*
 import org.javacs.kt.util.AsyncExecutor
 import org.javacs.kt.util.parseURI
 import org.javacs.kt.resolve.resolveMain
+import org.javacs.kt.position.offset
+import org.javacs.kt.listOverridableMembers
 import java.util.concurrent.CompletableFuture
 import java.nio.file.Paths
 
@@ -38,5 +40,13 @@ class KotlinProtocolExtensionService(
         resolveMain(compiledFile) + mapOf(
             "projectRoot" to workspacePath
         )
+    }
+
+    override fun overrideMember(position: TextDocumentPositionParams): CompletableFuture<List<CodeAction>> = async.compute {
+        val fileUri = parseURI(position.textDocument.uri)
+        val compiledFile = sp.currentVersion(fileUri)
+        val cursorOffset = offset(compiledFile.content, position.position)
+
+        listOverridableMembers(compiledFile, cursorOffset)
     }
 }

--- a/server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensionService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensionService.kt
@@ -5,7 +5,7 @@ import org.javacs.kt.util.AsyncExecutor
 import org.javacs.kt.util.parseURI
 import org.javacs.kt.resolve.resolveMain
 import org.javacs.kt.position.offset
-import org.javacs.kt.listOverridableMembers
+import org.javacs.kt.overridemembers.listOverridableMembers
 import java.util.concurrent.CompletableFuture
 import java.nio.file.Paths
 

--- a/server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensions.kt
@@ -15,4 +15,9 @@ interface KotlinProtocolExtensions {
 
     @JsonRequest
     fun mainClass(textDocument: TextDocumentIdentifier): CompletableFuture<Map<String, Any?>>
+
+    // TODO: what is the best return value in this case? CodeAction?
+    // TODO: should the naming be something like listOverrideableMembers? or something similar instead?
+    @JsonRequest
+    fun overrideMember(position: TextDocumentPositionParams): CompletableFuture<List<CodeAction>>
 }

--- a/server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensions.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinProtocolExtensions.kt
@@ -16,8 +16,6 @@ interface KotlinProtocolExtensions {
     @JsonRequest
     fun mainClass(textDocument: TextDocumentIdentifier): CompletableFuture<Map<String, Any?>>
 
-    // TODO: what is the best return value in this case? CodeAction?
-    // TODO: should the naming be something like listOverrideableMembers? or something similar instead?
     @JsonRequest
     fun overrideMember(position: TextDocumentPositionParams): CompletableFuture<List<CodeAction>>
 }

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractMembersQuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractMembersQuickFix.kt
@@ -7,6 +7,14 @@ import org.javacs.kt.index.SymbolIndex
 import org.javacs.kt.position.offset
 import org.javacs.kt.position.position
 import org.javacs.kt.util.toPath
+import org.javacs.kt.overridemembers.createFunctionStub
+import org.javacs.kt.overridemembers.createVariableStub
+import org.javacs.kt.overridemembers.getClassDescriptor
+import org.javacs.kt.overridemembers.getDeclarationPadding
+import org.javacs.kt.overridemembers.getNewMembersStartPosition
+import org.javacs.kt.overridemembers.getSuperClassTypeProjections
+import org.javacs.kt.overridemembers.hasNoBody
+import org.javacs.kt.overridemembers.overridesDeclaration
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
@@ -108,127 +116,3 @@ private fun getAbstractMembersStubs(file: CompiledFile, kotlinClass: KtClass) =
             null
         }
     }.flatten()
-
-// interfaces are ClassDescriptors by default. When calling AbstractClass super methods, we get a ClassConstructorDescriptor    
-private fun getClassDescriptor(descriptor: DeclarationDescriptor?): ClassDescriptor? = if (descriptor is ClassDescriptor) {
-    descriptor
-} else if (descriptor is ClassConstructorDescriptor) {
-    descriptor.containingDeclaration
-} else {
-    null
-}
-
-private fun getSuperClassTypeProjections(file: CompiledFile, superType: KtSuperTypeListEntry): List<TypeProjection> = superType.typeReference?.typeElement?.children?.filter {
-    it is KtTypeArgumentList
-}?.flatMap {
-    (it as KtTypeArgumentList).arguments
-}?.mapNotNull {
-    (file.referenceExpressionAtPoint(it?.startOffset ?: 0)?.second as? ClassDescriptor)?.defaultType?.asTypeProjection()
-} ?: emptyList()
-
-// Checks if the class overrides the given declaration
-private fun overridesDeclaration(kotlinClass: KtClass, descriptor: FunctionDescriptor): Boolean =
-    kotlinClass.declarations.any {
-        if (it.name == descriptor.name.asString() && it.hasModifier(KtTokens.OVERRIDE_KEYWORD)) {
-            if (it is KtNamedFunction) {
-                parametersMatch(it, descriptor)
-            } else {
-                true
-            }
-        } else {
-            false
-        }
-    }
-
-private fun overridesDeclaration(kotlinClass: KtClass, descriptor: PropertyDescriptor): Boolean =
-    kotlinClass.declarations.any {
-        it.name == descriptor.name.asString() && it.hasModifier(KtTokens.OVERRIDE_KEYWORD)
-    }
-
-// Checks if two functions have matching parameters
-private fun parametersMatch(function: KtNamedFunction, functionDescriptor: FunctionDescriptor): Boolean {
-    if (function.valueParameters.size == functionDescriptor.valueParameters.size) {
-        for (index in 0 until function.valueParameters.size) {
-            if (function.valueParameters[index].name != functionDescriptor.valueParameters[index].name.asString()) {
-                return false
-            } else if (function.valueParameters[index].typeReference?.typeName() != functionDescriptor.valueParameters[index].type.unwrappedType().toString()) {
-                // Note: Since we treat Java overrides as non nullable by default, the above test will fail when the user has made the type nullable.
-                // TODO: look into this
-                return false
-            }
-        }
-
-        if (function.typeParameters.size == functionDescriptor.typeParameters.size) {
-            for (index in 0 until function.typeParameters.size) {
-                if (function.typeParameters[index].variance != functionDescriptor.typeParameters[index].variance) {
-                    return false
-                }
-            }
-        }
-
-        return true
-    }
-
-    return false
-}
-
-private fun KtTypeReference.typeName(): String? = this.name ?: this.typeElement?.children?.filter {
-    it is KtSimpleNameExpression
-}?.map {
-    (it as KtSimpleNameExpression).getReferencedName()
-}?.firstOrNull()
-
-private fun createFunctionStub(function: FunctionDescriptor): String {
-    val name = function.name
-    val arguments = function.valueParameters.map { argument ->
-        val argumentName = argument.name
-        val argumentType = argument.type.unwrappedType()
-                    
-        "$argumentName: $argumentType"
-    }.joinToString(", ")
-    val returnType = function.returnType?.unwrappedType()?.toString()?.takeIf { "Unit" != it }
-    
-    return "override fun $name($arguments)${returnType?.let { ": $it" } ?: ""} { }"
-}
-
-private fun createVariableStub(variable: PropertyDescriptor): String {
-    val variableType = variable.returnType?.unwrappedType()?.toString()?.takeIf { "Unit" != it }
-    return "override val ${variable.name}${variableType?.let { ": $it" } ?: ""} = TODO(\"SET VALUE\")"
-}
-
-// about types: regular Kotlin types are marked T or T?, but types from Java are (T..T?) because nullability cannot be decided.
-// Therefore we have to unpack in case we have the Java type. Fortunately, the Java types are not marked nullable, so we default to non nullable types. Let the user decide if they want nullable types instead. With this implementation Kotlin types also keeps their nullability
-private fun KotlinType.unwrappedType(): KotlinType = this.unwrap().makeNullableAsSpecified(this.isMarkedNullable)
-
-private fun getDeclarationPadding(file: CompiledFile, kotlinClass: KtClass): String {
-    // If the class is not empty, the amount of padding is the same as the one in the last declaration of the class
-    val paddingSize = if (kotlinClass.declarations.isNotEmpty()) {
-        val lastFunctionStartOffset = kotlinClass.declarations.last().startOffset
-        position(file.content, lastFunctionStartOffset).character
-    } else {
-        // Otherwise, we just use a default tab size in addition to any existing padding
-        // on the class itself (note that the class could be inside another class, for example)
-        position(file.content, kotlinClass.startOffset).character + DEFAULT_TAB_SIZE
-    }
-
-    return " ".repeat(paddingSize)
-}
-
-private fun getNewMembersStartPosition(file: CompiledFile, kotlinClass: KtClass): Position? =
-    // If the class is not empty, the new member will be put right after the last declaration
-    if (kotlinClass.declarations.isNotEmpty()) {
-        val lastFunctionEndOffset = kotlinClass.declarations.last().endOffset
-        position(file.content, lastFunctionEndOffset)
-    } else { // Otherwise, the member is put at the beginning of the class
-        val body = kotlinClass.body
-        if (body != null) {
-            position(file.content, body.startOffset + 1)
-        } else {
-            // function has no body. We have to create one. New position is right after entire kotlin class text (with space)
-            val newPosCorrectLine = position(file.content, kotlinClass.startOffset + 1)
-            newPosCorrectLine.character = (kotlinClass.text.length + 2)
-            newPosCorrectLine
-        }
-    }
-
-private fun KtClass.hasNoBody() = null == this.body

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractMembersQuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/ImplementAbstractMembersQuickFix.kt
@@ -40,8 +40,6 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeProjection
 import org.jetbrains.kotlin.types.typeUtil.asTypeProjection
 
-private const val DEFAULT_TAB_SIZE = 4
-
 class ImplementAbstractMembersQuickFix : QuickFix {
     override fun compute(file: CompiledFile, index: SymbolIndex, range: Range, diagnostics: List<Diagnostic>): List<Either<Command, CodeAction>> {
         val diagnostic = findDiagnosticMatch(diagnostics, range)

--- a/server/src/main/kotlin/org/javacs/kt/overridemembers/OverrideMembers.kt
+++ b/server/src/main/kotlin/org/javacs/kt/overridemembers/OverrideMembers.kt
@@ -1,11 +1,301 @@
-package org.javacs.kt
+package org.javacs.kt.overridemembers
 
-import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.WorkspaceEdit
+import org.javacs.kt.CompiledFile
+import org.javacs.kt.util.toPath
+import org.javacs.kt.LOG
+import org.javacs.kt.position.position
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtSuperTypeListEntry
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.isInterface
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.isAbstract
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.types.TypeProjection
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.types.typeUtil.asTypeProjection
 
+// TODO: see where this should ideally be placed
+private const val DEFAULT_TAB_SIZE = 4
 
 fun listOverridableMembers(file: CompiledFile, cursor: Int): List<CodeAction> {
-    // TODO: implement 
+    val kotlinClass = file.parseAtPoint(cursor)
 
-    return listOf()
+    if (kotlinClass is KtClass) {
+        return createOverrideAlternatives(file, kotlinClass)
+    }
+
+    return emptyList()
 }
+
+private fun createOverrideAlternatives(file: CompiledFile, kotlinClass: KtClass): List<CodeAction> {
+    // Get the functions that need to be implemented
+    val membersToImplement = getUnimplementedMembersStubs(file, kotlinClass)
+
+    val uri = file.parse.toPath().toUri().toString()
+
+    // Get the padding to be introduced before the member declarations
+    val padding = getDeclarationPadding(file, kotlinClass)
+
+    // Get the location where the new code will be placed
+    val newMembersStartPosition = getNewMembersStartPosition(file, kotlinClass)
+    // TODO: if both used here and in the abstract member stuff.... should we put it in a method both can use?
+    // TODO: how should this be implemented? 
+    // val bodyAppendBeginning =
+    //     listOf(TextEdit(Range(newMembersStartPosition, newMembersStartPosition), "{")).takeIf {
+    //                kotlinClass.hasNoBody()
+    //            }
+    //            ?: emptyList()
+    // val bodyAppendEnd =
+    //     listOf(
+    //         TextEdit(
+    //             Range(newMembersStartPosition, newMembersStartPosition),
+    //             System.lineSeparator() + "}")
+    //     )
+    //     .takeIf { kotlinClass.hasNoBody() }
+    // ?: emptyList()
+
+    LOG.info("Members: {}", membersToImplement)
+    
+    // loop through the memberstoimplement and create code actions
+    return membersToImplement.map { member ->
+        val newText = System.lineSeparator() + System.lineSeparator() + padding + member
+        val textEdit = TextEdit(Range(newMembersStartPosition, newMembersStartPosition), newText)
+
+        // TODO: how should we get the name of the property? if needed?
+        val codeAction = CodeAction()
+        codeAction.edit = WorkspaceEdit(mapOf(uri to listOf(textEdit)))
+        codeAction.title = member
+
+        codeAction
+    }
+}
+
+// TODO: any way can repeat less code between this and the getAbstractMembersStubs in the ImplementAbstractMembersQuickfix?
+private fun getUnimplementedMembersStubs(file: CompiledFile, kotlinClass: KtClass): List<String> =
+        // For each of the super types used by this class
+        kotlinClass
+                .superTypeListEntries
+                .mapNotNull {
+                    // Find the definition of this super type
+                    val referenceAtPoint = file.referenceExpressionAtPoint(it.startOffset)
+                    val descriptor = referenceAtPoint?.second
+                    val classDescriptor = getClassDescriptor(descriptor)
+
+                    // If the super class is abstract, interface or just plain open
+                    if (null != classDescriptor && classDescriptor.canBeExtended()
+                    ) {
+                        val superClassTypeArguments = getSuperClassTypeProjections(file, it)
+                        classDescriptor
+                                .getMemberScope(superClassTypeArguments)
+                                .getContributedDescriptors()
+                                .filter { classMember ->
+                                    (classMember is FunctionDescriptor &&
+                                            classMember.canBeOverriden() &&
+                                            !overridesDeclaration(kotlinClass, classMember)) ||
+                                        (classMember is PropertyDescriptor &&
+                                            classMember.canBeOverriden() &&
+                                            !overridesDeclaration(kotlinClass, classMember))
+                                }
+                                .mapNotNull { member ->
+                                    when (member) {
+                                        is FunctionDescriptor -> createFunctionStub(member)
+                                        is PropertyDescriptor -> createVariableStub(member)
+                                        else -> null
+                                    }
+                                }
+                    } else {
+                        null
+                    }
+                }
+                .flatten()
+
+private fun ClassDescriptor.canBeExtended() = this.kind.isInterface ||
+    this.modality == Modality.ABSTRACT ||
+    this.modality == Modality.OPEN
+
+private fun FunctionDescriptor.canBeOverriden() = Modality.ABSTRACT == this.modality || Modality.OPEN == this.modality
+
+private fun PropertyDescriptor.canBeOverriden() = Modality.ABSTRACT == this.modality || Modality.OPEN == this.modality       
+            
+// interfaces are ClassDescriptors by default. When calling AbstractClass super methods, we get a ClassConstructorDescriptor
+fun getClassDescriptor(descriptor: DeclarationDescriptor?): ClassDescriptor? =
+        if (descriptor is ClassDescriptor) {
+            descriptor
+        } else if (descriptor is ClassConstructorDescriptor) {
+            descriptor.containingDeclaration
+        } else {
+            null
+        }
+
+fun getSuperClassTypeProjections(
+        file: CompiledFile,
+        superType: KtSuperTypeListEntry
+): List<TypeProjection> =
+        superType
+                .typeReference
+                ?.typeElement
+                ?.children
+                ?.filter { it is KtTypeArgumentList }
+                ?.flatMap { (it as KtTypeArgumentList).arguments }
+                ?.mapNotNull {
+                    (file.referenceExpressionAtPoint(it?.startOffset ?: 0)?.second as?
+                                    ClassDescriptor)
+                            ?.defaultType?.asTypeProjection()
+                }
+                ?: emptyList()
+
+// Checks if the class overrides the given declaration
+fun overridesDeclaration(kotlinClass: KtClass, descriptor: FunctionDescriptor): Boolean =
+        kotlinClass.declarations.any {
+            if (it.name == descriptor.name.asString() && it.hasModifier(KtTokens.OVERRIDE_KEYWORD)
+            ) {
+                if (it is KtNamedFunction) {
+                    parametersMatch(it, descriptor)
+                } else {
+                    true
+                }
+            } else {
+                false
+            }
+        }
+
+fun overridesDeclaration(kotlinClass: KtClass, descriptor: PropertyDescriptor): Boolean =
+        kotlinClass.declarations.any {
+            it.name == descriptor.name.asString() && it.hasModifier(KtTokens.OVERRIDE_KEYWORD)
+        }
+
+// Checks if two functions have matching parameters
+private fun parametersMatch(
+        function: KtNamedFunction,
+        functionDescriptor: FunctionDescriptor
+): Boolean {
+    if (function.valueParameters.size == functionDescriptor.valueParameters.size) {
+        for (index in 0 until function.valueParameters.size) {
+            LOG.info("Method: {} {} - {} {}", function.valueParameters[index].name, functionDescriptor.valueParameters[index].name.asString(),  function.valueParameters[index].typeReference?.typeName(), functionDescriptor.valueParameters[index]
+                                    .type
+                                    .unwrappedType()
+                                    .toString())
+            if (function.valueParameters[index].name !=
+                            functionDescriptor.valueParameters[index].name.asString()
+            ) {
+                return false
+            } else if (function.valueParameters[index].typeReference?.typeName() !=
+                            functionDescriptor.valueParameters[index]
+                                    .type
+                                    .unwrappedType()
+                                    .toString()
+            ) {
+                // Note: Since we treat Java overrides as non nullable by default, the above test
+                // will fail when the user has made the type nullable.
+                // TODO: look into this
+                // TODO: look into the weird issue with equals...
+                return false
+            }
+        }
+
+        if (function.typeParameters.size == functionDescriptor.typeParameters.size) {
+            for (index in 0 until function.typeParameters.size) {
+                if (function.typeParameters[index].variance !=
+                                functionDescriptor.typeParameters[index].variance
+                ) {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+
+    return false
+}
+
+private fun KtTypeReference.typeName(): String? =
+        this.name
+                ?: this.typeElement
+                        ?.children
+                        ?.filter { it is KtSimpleNameExpression }
+                        ?.map { (it as KtSimpleNameExpression).getReferencedName() }
+                        ?.firstOrNull()
+
+fun createFunctionStub(function: FunctionDescriptor): String {
+    val name = function.name
+    val arguments =
+            function.valueParameters
+                    .map { argument ->
+                        val argumentName = argument.name
+                        val argumentType = argument.type.unwrappedType()
+
+                        "$argumentName: $argumentType"
+                    }
+                    .joinToString(", ")
+    val returnType = function.returnType?.unwrappedType()?.toString()?.takeIf { "Unit" != it }
+
+    return "override fun $name($arguments)${returnType?.let { ": $it" } ?: ""} { }"
+}
+
+fun createVariableStub(variable: PropertyDescriptor): String {
+    val variableType = variable.returnType?.unwrappedType()?.toString()?.takeIf { "Unit" != it }
+    return "override val ${variable.name}${variableType?.let { ": $it" } ?: ""} = TODO(\"SET VALUE\")"
+}
+
+// about types: regular Kotlin types are marked T or T?, but types from Java are (T..T?) because
+// nullability cannot be decided.
+// Therefore we have to unpack in case we have the Java type. Fortunately, the Java types are not
+// marked nullable, so we default to non nullable types. Let the user decide if they want nullable
+// types instead. With this implementation Kotlin types also keeps their nullability
+private fun KotlinType.unwrappedType(): KotlinType =
+        this.unwrap().makeNullableAsSpecified(this.isMarkedNullable)
+
+fun getDeclarationPadding(file: CompiledFile, kotlinClass: KtClass): String {
+    // If the class is not empty, the amount of padding is the same as the one in the last
+    // declaration of the class
+    val paddingSize =
+            if (kotlinClass.declarations.isNotEmpty()) {
+                val lastFunctionStartOffset = kotlinClass.declarations.last().startOffset
+                position(file.content, lastFunctionStartOffset).character
+            } else {
+                // Otherwise, we just use a default tab size in addition to any existing padding
+                // on the class itself (note that the class could be inside another class, for
+                // example)
+                position(file.content, kotlinClass.startOffset).character + DEFAULT_TAB_SIZE
+            }
+
+    return " ".repeat(paddingSize)
+}
+
+fun getNewMembersStartPosition(file: CompiledFile, kotlinClass: KtClass): Position? =
+        // If the class is not empty, the new member will be put right after the last declaration
+        if (kotlinClass.declarations.isNotEmpty()) {
+            val lastFunctionEndOffset = kotlinClass.declarations.last().endOffset
+            position(file.content, lastFunctionEndOffset)
+        } else { // Otherwise, the member is put at the beginning of the class
+            val body = kotlinClass.body
+            if (body != null) {
+                position(file.content, body.startOffset + 1)
+            } else {
+                // function has no body. We have to create one. New position is right after entire
+                // kotlin class text (with space)
+                val newPosCorrectLine = position(file.content, kotlinClass.startOffset + 1)
+                newPosCorrectLine.character = (kotlinClass.text.length + 2)
+                newPosCorrectLine
+            }
+        }
+
+fun KtClass.hasNoBody() = null == this.body

--- a/server/src/main/kotlin/org/javacs/kt/overridemembers/OverrideMembers.kt
+++ b/server/src/main/kotlin/org/javacs/kt/overridemembers/OverrideMembers.kt
@@ -90,12 +90,9 @@ private fun getUnimplementedMembersStubs(file: CompiledFile, kotlinClass: KtClas
                     .getMemberScope(superClassTypeArguments)
                     .getContributedDescriptors()
                     .filter { classMember ->
-                        (classMember is FunctionDescriptor &&
+                        classMember is MemberDescriptor &&
                          classMember.canBeOverriden() &&
-                         !overridesDeclaration(kotlinClass, classMember)) ||
-                        (classMember is PropertyDescriptor &&
-                         classMember.canBeOverriden() &&
-                         !overridesDeclaration(kotlinClass, classMember))
+                         !overridesDeclaration(kotlinClass, classMember)
                     }
                     .mapNotNull { member ->
                         when (member) {

--- a/server/src/main/kotlin/org/javacs/kt/overridemembers/OverrideMembers.kt
+++ b/server/src/main/kotlin/org/javacs/kt/overridemembers/OverrideMembers.kt
@@ -1,0 +1,11 @@
+package org.javacs.kt
+
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.CodeAction
+
+
+fun listOverridableMembers(file: CompiledFile, cursor: Int): List<CodeAction> {
+    // TODO: implement 
+
+    return listOf()
+}

--- a/server/src/test/kotlin/org/javacs/kt/OverrideMemberTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/OverrideMemberTest.kt
@@ -13,9 +13,6 @@ import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
 import org.junit.Assert.assertThat
 
-// TODO: what should the title be? just the signature? or the name of the member? should we separate between methods and variables?
-// easiest is probably just to show the signatures?
-
 class OverrideMemberTest : SingleFileTestFixture("overridemember", "OverrideMembers.kt") {
 
     val root = testResourcesRoot().resolve(workspaceRoot)

--- a/server/src/test/kotlin/org/javacs/kt/OverrideMemberTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/OverrideMemberTest.kt
@@ -1,0 +1,77 @@
+package org.javacs.kt
+
+import com.google.gson.Gson
+import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentPositionParams
+import org.junit.Test
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.Assert.assertThat
+
+// TODO: what should the title be? just the signature? or the name of the member? should we separate between methods and variables?
+
+class OverrideMemberTest : SingleFileTestFixture("overridemember", "OverrideMembers.kt") {
+
+    val root = testResourcesRoot().resolve(workspaceRoot)
+    val fileUri = root.resolve(file).toUri().toString()
+    
+    @Test
+    fun `should show all overrides for class`() {
+        val result = languageServer.getProtocolExtensionService().overrideMember(TextDocumentPositionParams(TextDocumentIdentifier(fileUri), position(9, 8))).get()
+   
+        assertThat(result, hasSize(2))
+        
+        val firstCodeAction = result[0]
+        assertThat(firstCodeAction.title, equalTo("text"))
+
+        val firstTextEdit = firstCodeAction.edit.changes
+        assertThat(firstTextEdit.containsKey(fileUri), equalTo(true))
+        assertThat(firstTextEdit[fileUri], hasSize(1))
+        
+        val memberToImplementEdit = firstTextEdit[fileUri]?.get(0)
+        assertThat(memberToImplementEdit?.range, equalTo(range(9, 32, 9, 32)))
+        assertThat(memberToImplementEdit?.newText, equalTo(System.lineSeparator() + System.lineSeparator() + "    override val text: String = ???"))
+
+
+        val secondCodeAction = result[1]
+        assertThat(secondCodeAction.title, equalTo("print"))
+
+        val secondTextEdit = secondCodeAction.edit.changes
+        assertThat(secondTextEdit.containsKey(fileUri), equalTo(true))
+        assertThat(secondTextEdit[fileUri], hasSize(1))
+        
+        val functionToImplementEdit = secondTextEdit[fileUri]?.get(0)
+        assertThat(functionToImplementEdit?.range, equalTo(range(9, 32, 9, 32)))
+        assertThat(functionToImplementEdit?.newText, equalTo(System.lineSeparator() + System.lineSeparator() + "    override fun print() {}"))
+    }
+
+    @Test
+    fun `should show one override for class where other alternatives are already implemented`() {
+        val result = languageServer.getProtocolExtensionService().overrideMember(TextDocumentPositionParams(TextDocumentIdentifier(fileUri), position(11, 8))).get()
+   
+        assertThat(result, hasSize(1))
+      
+        val codeAction = result[0]
+        assertThat(codeAction.title, equalTo("print"))
+
+        val textEdit = codeAction.edit.changes
+        assertThat(textEdit.containsKey(fileUri), equalTo(true))
+        assertThat(textEdit[fileUri], hasSize(1)) 
+        
+        val functionToImplementEdit = textEdit[fileUri]?.get(0)
+        assertThat(functionToImplementEdit?.range, equalTo(range(12, 57, 12, 57)))
+        assertThat(functionToImplementEdit?.newText, equalTo(System.lineSeparator() + System.lineSeparator() + "    override fun print() {}"))
+    }
+
+    @Test
+    fun `should show NO overrides for class where all other alternatives are already implemented`() {
+        val result = languageServer.getProtocolExtensionService().overrideMember(TextDocumentPositionParams(TextDocumentIdentifier(fileUri), position(15, 8))).get()
+   
+        assertThat(result, hasSize(0))
+    }
+
+    // TODO: test for kotlin sdk and jdk classes to verify that it works
+}

--- a/server/src/test/kotlin/org/javacs/kt/OverrideMemberTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/OverrideMemberTest.kt
@@ -7,11 +7,14 @@ import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentPositionParams
 import org.junit.Test
+import org.hamcrest.core.Every.everyItem
+import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
 import org.junit.Assert.assertThat
 
 // TODO: what should the title be? just the signature? or the name of the member? should we separate between methods and variables?
+// easiest is probably just to show the signatures?
 
 class OverrideMemberTest : SingleFileTestFixture("overridemember", "OverrideMembers.kt") {
 
@@ -21,49 +24,50 @@ class OverrideMemberTest : SingleFileTestFixture("overridemember", "OverrideMemb
     @Test
     fun `should show all overrides for class`() {
         val result = languageServer.getProtocolExtensionService().overrideMember(TextDocumentPositionParams(TextDocumentIdentifier(fileUri), position(9, 8))).get()
-   
-        assertThat(result, hasSize(2))
+
+        val titles = result.map { it.title }
+        val edits = result.flatMap { it.edit.changes[fileUri]!! }
+        val newTexts = edits.map { it.newText }
+        val ranges = edits.map { it.range }
+
+        assertThat(titles, containsInAnyOrder("override val text: String = TODO(\"SET VALUE\")",
+                                              "override fun print() { }",
+                                              "override fun equals(other: Any?): Boolean { }",
+                                              "override fun hashCode(): Int { }",
+                                              "override fun toString(): String { }"))
+
+        val padding = System.lineSeparator() + System.lineSeparator() + "    "
+        assertThat(newTexts, containsInAnyOrder(padding + "override val text: String = TODO(\"SET VALUE\")",
+                                                padding + "override fun print() { }",
+                                                padding + "override fun equals(other: Any?): Boolean { }",
+                                                padding + "override fun hashCode(): Int { }",
+                                                padding + "override fun toString(): String { }"))
         
-        val firstCodeAction = result[0]
-        assertThat(firstCodeAction.title, equalTo("text"))
 
-        val firstTextEdit = firstCodeAction.edit.changes
-        assertThat(firstTextEdit.containsKey(fileUri), equalTo(true))
-        assertThat(firstTextEdit[fileUri], hasSize(1))
-        
-        val memberToImplementEdit = firstTextEdit[fileUri]?.get(0)
-        assertThat(memberToImplementEdit?.range, equalTo(range(9, 32, 9, 32)))
-        assertThat(memberToImplementEdit?.newText, equalTo(System.lineSeparator() + System.lineSeparator() + "    override val text: String = ???"))
-
-
-        val secondCodeAction = result[1]
-        assertThat(secondCodeAction.title, equalTo("print"))
-
-        val secondTextEdit = secondCodeAction.edit.changes
-        assertThat(secondTextEdit.containsKey(fileUri), equalTo(true))
-        assertThat(secondTextEdit[fileUri], hasSize(1))
-        
-        val functionToImplementEdit = secondTextEdit[fileUri]?.get(0)
-        assertThat(functionToImplementEdit?.range, equalTo(range(9, 32, 9, 32)))
-        assertThat(functionToImplementEdit?.newText, equalTo(System.lineSeparator() + System.lineSeparator() + "    override fun print() {}"))
+        assertThat(ranges, everyItem(equalTo(range(9, 31, 9, 31))))
     }
 
     @Test
-    fun `should show one override for class where other alternatives are already implemented`() {
+    fun `should show one less override for class where one member is already implemented`() {
         val result = languageServer.getProtocolExtensionService().overrideMember(TextDocumentPositionParams(TextDocumentIdentifier(fileUri), position(11, 8))).get()
-   
-        assertThat(result, hasSize(1))
-      
-        val codeAction = result[0]
-        assertThat(codeAction.title, equalTo("print"))
 
-        val textEdit = codeAction.edit.changes
-        assertThat(textEdit.containsKey(fileUri), equalTo(true))
-        assertThat(textEdit[fileUri], hasSize(1)) 
+        val titles = result.map { it.title }
+        val edits = result.flatMap { it.edit.changes[fileUri]!! }
+        val newTexts = edits.map { it.newText }
+        val ranges = edits.map { it.range }
+
+        assertThat(titles, containsInAnyOrder("override fun print() { }",
+                                              "override fun equals(other: Any?): Boolean { }",
+                                              "override fun hashCode(): Int { }",
+                                              "override fun toString(): String { }"))
+
+        val padding = System.lineSeparator() + System.lineSeparator() + "    "
+        assertThat(newTexts, containsInAnyOrder(padding + "override fun print() { }",
+                                                padding + "override fun equals(other: Any?): Boolean { }",
+                                                padding + "override fun hashCode(): Int { }",
+                                                padding + "override fun toString(): String { }"))
         
-        val functionToImplementEdit = textEdit[fileUri]?.get(0)
-        assertThat(functionToImplementEdit?.range, equalTo(range(12, 57, 12, 57)))
-        assertThat(functionToImplementEdit?.newText, equalTo(System.lineSeparator() + System.lineSeparator() + "    override fun print() {}"))
+        assertThat(ranges, everyItem(equalTo(range(12, 56, 12, 56))))
     }
 
     @Test
@@ -73,5 +77,28 @@ class OverrideMemberTest : SingleFileTestFixture("overridemember", "OverrideMemb
         assertThat(result, hasSize(0))
     }
 
+    @Test
+    fun `should find method in open class`() {
+        val result = languageServer.getProtocolExtensionService().overrideMember(TextDocumentPositionParams(TextDocumentIdentifier(fileUri), position(37, 8))).get()
+
+        val titles = result.map { it.title }
+        val edits = result.flatMap { it.edit.changes[fileUri]!! }
+        val newTexts = edits.map { it.newText }
+        val ranges = edits.map { it.range }
+
+        assertThat(titles, containsInAnyOrder("override fun numOpenDoorsWithName(input: String): Int { }",
+                                              "override fun equals(other: Any?): Boolean { }",
+                                              "override fun hashCode(): Int { }",
+                                              "override fun toString(): String { }"))
+
+        val padding = System.lineSeparator() + System.lineSeparator() + "    "
+        assertThat(newTexts, containsInAnyOrder(padding + "override fun numOpenDoorsWithName(input: String): Int { }",
+                                                padding + "override fun equals(other: Any?): Boolean { }",
+                                                padding + "override fun hashCode(): Int { }",
+                                                padding + "override fun toString(): String { }"))
+        
+        assertThat(ranges, everyItem(equalTo(range(37, 25, 37, 25))))
+    }
+    
     // TODO: test for kotlin sdk and jdk classes to verify that it works
 }

--- a/server/src/test/kotlin/org/javacs/kt/OverrideMemberTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/OverrideMemberTest.kt
@@ -100,5 +100,50 @@ class OverrideMemberTest : SingleFileTestFixture("overridemember", "OverrideMemb
         assertThat(ranges, everyItem(equalTo(range(37, 25, 37, 25))))
     }
     
-    // TODO: test for kotlin sdk and jdk classes to verify that it works
+    @Test
+    fun `should find members in jdk object`() {
+        val result = languageServer.getProtocolExtensionService().overrideMember(TextDocumentPositionParams(TextDocumentIdentifier(fileUri), position(39, 9))).get()
+
+        val titles = result.map { it.title }
+        val edits = result.flatMap { it.edit.changes[fileUri]!! }
+        val newTexts = edits.map { it.newText }
+        val ranges = edits.map { it.range }
+
+        assertThat(titles, containsInAnyOrder("override fun equals(other: Any?): Boolean { }",
+                                              "override fun hashCode(): Int { }",
+                                              "override fun toString(): String { }",
+                                              "override fun run() { }",
+                                              "override fun clone(): Any { }",
+                                              "override fun start() { }",
+                                              "override fun interrupt() { }",
+                                              "override fun isInterrupted(): Boolean { }",
+                                              "override fun countStackFrames(): Int { }",
+                                              "override fun getContextClassLoader(): ClassLoader { }",
+                                              "override fun setContextClassLoader(cl: ClassLoader) { }",
+                                              "override fun getStackTrace(): (Array<(StackTraceElement..StackTraceElement?)>..Array<out (StackTraceElement..StackTraceElement?)>) { }",
+                                              "override fun getId(): Long { }",
+                                              "override fun getState(): State { }",
+                                              "override fun getUncaughtExceptionHandler(): UncaughtExceptionHandler { }",
+                                              "override fun setUncaughtExceptionHandler(eh: UncaughtExceptionHandler) { }"))
+
+        val padding = System.lineSeparator() + System.lineSeparator() + "    "
+        assertThat(newTexts, containsInAnyOrder(padding + "override fun equals(other: Any?): Boolean { }",
+                                                padding + "override fun hashCode(): Int { }",
+                                                padding + "override fun toString(): String { }",
+                                                padding + "override fun run() { }",
+                                                padding + "override fun clone(): Any { }",
+                                                padding + "override fun start() { }",
+                                                padding + "override fun interrupt() { }",
+                                                padding + "override fun isInterrupted(): Boolean { }",
+                                                padding + "override fun countStackFrames(): Int { }",
+                                                padding + "override fun getContextClassLoader(): ClassLoader { }",
+                                                padding + "override fun setContextClassLoader(cl: ClassLoader) { }",
+                                                padding + "override fun getStackTrace(): (Array<(StackTraceElement..StackTraceElement?)>..Array<out (StackTraceElement..StackTraceElement?)>) { }",
+                                                padding + "override fun getId(): Long { }",
+                                                padding + "override fun getState(): State { }",
+                                                padding + "override fun getUncaughtExceptionHandler(): UncaughtExceptionHandler { }",
+                                                padding + "override fun setUncaughtExceptionHandler(eh: UncaughtExceptionHandler) { }"))
+        
+        assertThat(ranges, everyItem(equalTo(range(39, 25, 39, 25))))
+    }
 }

--- a/server/src/test/resources/overridemember/OverrideMembers.kt
+++ b/server/src/test/resources/overridemember/OverrideMembers.kt
@@ -1,0 +1,21 @@
+interface Printable {
+    val text: String
+
+    fun print() {
+        println("not implemented yet yo")
+    }
+}
+
+class MyPrintable: Printable {}
+
+class OtherPrintable: Printable {
+    override val text: String = "you had me at lasagna"
+}
+
+class CompletePrintable: Printable {
+    override val text: String = "something something something darkside"
+
+    override fun print() {
+        println("not implemented yet yo")
+    }
+}

--- a/server/src/test/resources/overridemember/OverrideMembers.kt
+++ b/server/src/test/resources/overridemember/OverrideMembers.kt
@@ -35,3 +35,5 @@ open class MyOpen {
 }
 
 class Closed: MyOpen() {}
+
+class MyThread: Thread {}

--- a/server/src/test/resources/overridemember/OverrideMembers.kt
+++ b/server/src/test/resources/overridemember/OverrideMembers.kt
@@ -15,7 +15,23 @@ class OtherPrintable: Printable {
 class CompletePrintable: Printable {
     override val text: String = "something something something darkside"
 
+    override fun equals(other: Any?): Boolean { return true }
+
+    override fun hashCode(): Int { return 1 }
+
+    override fun toString(): String {
+        return "something something complete"
+    }
+
     override fun print() {
         println("not implemented yet yo")
     }
 }
+
+open class MyOpen {
+    open fun numOpenDoorsWithName(input: String): Int {
+        return 2
+    }
+}
+
+class Closed: MyOpen() {}


### PR DESCRIPTION
## General info
Override any member that is currently not implemented in the current class. This includes open functions, functions with default implementations, open members, abstract stuff etc. The main difference here is that this is general override member functionality, NOT JUST abstract members like the quick fix does. This is super useful for cases where you need to override a default implementation (e.g toString, Thread run, lsp4j interface methods like in TextDocumentService etc.), NOT just the unimplemented abstract ones. For me it would be super useful for my day job using Kotlin 😄 Having to google api docs to find signatures are a pain in the ass just for doing simple stuff like this. 


Two small issues:
- Implicit Any/Object methods does not seem to work. I can't really figure out why. The methods from them show up if the class has at least one superclass. Unsure on how to solve this, there are a TODO in the code at a relevant place. 
- No support for empty class bodies (i.e, no brackets). Not sure how to solve that. Probably not super important either. 


I think these are very minor. Just having this functionality in place would at least make me more productive using the language server 😄 


The quick fix for abstract methods and this new functionality, share a lot of code. I've moved most of the code to the override-package, as that was the most logical place to put it. 

Fixes #359 


This is a new protocol extension, so each lsp-client will need to have an implementation to use it. I've only done one for Emacs so far, and speaking of...

## Emacs screenshots
Running lsp-kotlin-override-members on MyClass (notice that multiple selections are possible!):
<img width="896" alt="image" src="https://user-images.githubusercontent.com/5732795/182887490-ccdd278f-7624-4998-a4f9-9821c11fad16.png">

When we click enter:
<img width="896" alt="image" src="https://user-images.githubusercontent.com/5732795/182887648-125040e1-2e39-490f-95b7-55339f19d04c.png">
(yes, it is the same sample project I often use for screenshot. A boring Spring Boot demo app)


Yes, it works for external interfaces and open classes as well, don't worry 🙂 There is an example of JDK Thread in the tests (in this PR, not in Emacs)


Emacs client implementation (lsp-mode):
https://github.com/themkat/lsp-mode/blob/kotlin_overrides/clients/lsp-kotlin.el#L224

Will make a PR for it once this PR has been merged. Just in case something changes.


~Will see if I can find the time to make a VSCode version or not. If not, I will make an issue in the vscode-kotlin repo with enough details to get someone else started~ 🙂 Really want to work on either Type hierarchy or Javadoc for Kotlin SDK and the JDK instead 😛 

**EDIT:** Made a VSCode version, as I was bored after work yesterday: https://github.com/fwcd/vscode-kotlin/pull/104