### PR TITLE
Resolve kotlin-stdlib.jar from snap install

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/BackupClassPathResolver.kt
@@ -18,6 +18,7 @@ object BackupClassPathResolver : ClassPathResolver {
 fun findKotlinStdlib(): Path? =
     findLocalArtifact("org.jetbrains.kotlin", "kotlin-stdlib")
     ?: findKotlinCliCompilerLibrary("kotlin-stdlib")
+    ?: findAlternativeLibraryLocation("kotlin-stdlib")
 
 private fun findLocalArtifact(group: String, artifact: String) =
     tryResolving("$artifact using Maven") { tryFindingLocalArtifactUsing(group, artifact, findLocalArtifactDirUsingMaven(group, artifact)) }
@@ -69,6 +70,11 @@ private fun findKotlinCliCompilerLibrary(name: String): Path? =
         ?.findFirst()
         ?.orElse(null)
 
+
+// alternative library locations like for snap
+// (can probably just use elvis operator and multiple similar expressions for other install directories)
+private fun findAlternativeLibraryLocation(name: String): Path? =
+    Paths.get("/snap/kotlin/current/lib/${name}.jar").existsOrNull()
 
 private fun Path.existsOrNull() =
     if (Files.exists(this)) this else null


### PR DESCRIPTION
In https://github.com/fwcd/vscode-kotlin/issues/101, a user was using snap to install Kotlin. In my last classpath-resolving-fix PR, I could not get snap working (I mostly use M1 Macs these days, which is ARM and have issues installing the kotlin package as it is only provided for x86/x64). Today I found an older machine (x86), and experimented with snap and installed kotlin that way. I could not resolve the location of stdlib directly using the location of kotlinc. kotlinc resolved to some weird snap-location, and stdlib jars seems to be located in `/snap/kotlin/current/lib/`. We know from the issue I linked to, and the output the user gave, that the implementation (pre other PR) did not resolve the stdlib location.


My solution is to try to resolve a common snap install path directly. This should at least give some support for installs using snap (even though there might not be that many). Hopefully this will make at least the few people installing kotlin using snap happy 🙂 