### PR TITLE
URGENT: Fix startup issue for language server caused by lsp4j 0.15 upgrade

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -6,6 +6,7 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonDelegate
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.services.LanguageClientAware
 import org.eclipse.lsp4j.services.LanguageServer
+import org.eclipse.lsp4j.services.NotebookDocumentService
 import org.javacs.kt.command.ALL_COMMANDS
 import org.javacs.kt.externalsources.*
 import org.javacs.kt.util.AsyncExecutor
@@ -162,4 +163,10 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
     }
 
     override fun exit() {}
+
+    // Fixed in https://github.com/eclipse/lsp4j/commit/04b0c6112f0a94140e22b8b15bb5a90d5a0ed851
+    // Causes issue in lsp 0.15
+    override fun getNotebookDocumentService(): NotebookDocumentService? {
+		return null;
+	}
 }


### PR DESCRIPTION
Sorry @fwcd , seems like I was too quick to approve a recent PR:
https://github.com/fwcd/kotlin-language-server/pull/381

lsp4j 0.15 causes the following startup issue in many clients:
```
Exception in thread "main" java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$recursiveFindRpcMethods$2(GenericEndpoint.java:83)
	at org.eclipse.lsp4j.jsonrpc.services.AnnotationUtil.findDelegateSegments(AnnotationUtil.java:32)
	at org.eclipse.lsp4j.jsonrpc.services.AnnotationUtil.findDelegateSegments(AnnotationUtil.java:28)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.recursiveFindRpcMethods(GenericEndpoint.java:74)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.<init>(GenericEndpoint.java:54)
	at org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints.toEndpoint(ServiceEndpoints.java:72)
	at org.eclipse.lsp4j.jsonrpc.Launcher$Builder.createRemoteEndpoint(Launcher.java:348)
	at org.eclipse.lsp4j.jsonrpc.Launcher$Builder.create(Launcher.java:320)
	at org.eclipse.lsp4j.launch.LSPLauncher.createServerLauncher(LSPLauncher.java:90)
	at org.javacs.kt.MainKt.main(Main.kt:44)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:119)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$recursiveFindRpcMethods$2(GenericEndpoint.java:76)
	... 9 more
Caused by: java.lang.UnsupportedOperationException
	at org.eclipse.lsp4j.services.LanguageServer.getNotebookDocumentService(LanguageServer.java:93)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	... 11 more
```


The issue has been fixed in a later commit in lsp4j (probably included in next version 0.16). I was able to do the same in our language server and fix the startup issues.
https://github.com/eclipse/lsp4j/commit/04b0c6112f0a94140e22b8b15bb5a90d5a0ed851


Emacs gives a warning of a null value, but ignores it. VSCode works like a charm when I tested it just now. 


Again, sorry for not noticing this before I approved the other PR 🙁 