### PR TITLE
Fix issue where code action doesn't show up, unless entire text marked

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt
@@ -7,6 +7,7 @@ import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.javacs.kt.CompiledFile
 import org.javacs.kt.index.SymbolIndex
+import org.javacs.kt.util.isSubrangeOf
 import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
 import org.jetbrains.kotlin.diagnostics.Diagnostic as KotlinDiagnostic
 
@@ -16,15 +17,7 @@ interface QuickFix {
 }
 
 fun diagnosticMatch(diagnostic: Diagnostic, range: Range, diagnosticTypes: Set<String>): Boolean =
-    isDiagnosticInRange(diagnostic, range) && diagnosticTypes.contains(diagnostic.code.left)
-
-// for a diagnostic to be in range the lines should be the same, and
-//  the input character range should be within the bounds of the diagnostics range.
-private fun isDiagnosticInRange(diagnostic: Diagnostic, range: Range): Boolean {
-    val diagnosticRange = diagnostic.range
-    return diagnosticRange.start.line == range.start.line && diagnosticRange.end.line == range.end.line &&
-        diagnosticRange.start.character <= range.start.character && diagnosticRange.end.character >= range.end.character
-}
+    range.isSubrangeOf(diagnostic.range) && diagnosticTypes.contains(diagnostic.code.left)
 
 fun diagnosticMatch(diagnostic: KotlinDiagnostic, startCursor: Int, endCursor: Int, diagnosticTypes: Set<String>): Boolean =
     diagnostic.textRanges.any { it.startOffset <= startCursor && it.endOffset >= endCursor } && diagnosticTypes.contains(diagnostic.factory.name)

--- a/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt
+++ b/server/src/main/kotlin/org/javacs/kt/codeaction/quickfix/QuickFix.kt
@@ -16,10 +16,18 @@ interface QuickFix {
 }
 
 fun diagnosticMatch(diagnostic: Diagnostic, range: Range, diagnosticTypes: Set<String>): Boolean =
-    diagnostic.range.equals(range) && diagnosticTypes.contains(diagnostic.code.left)
+    isDiagnosticInRange(diagnostic, range) && diagnosticTypes.contains(diagnostic.code.left)
+
+// for a diagnostic to be in range the lines should be the same, and
+//  the input character range should be within the bounds of the diagnostics range.
+private fun isDiagnosticInRange(diagnostic: Diagnostic, range: Range): Boolean {
+    val diagnosticRange = diagnostic.range
+    return diagnosticRange.start.line == range.start.line && diagnosticRange.end.line == range.end.line &&
+        diagnosticRange.start.character <= range.start.character && diagnosticRange.end.character >= range.end.character
+}
 
 fun diagnosticMatch(diagnostic: KotlinDiagnostic, startCursor: Int, endCursor: Int, diagnosticTypes: Set<String>): Boolean =
-    diagnostic.textRanges.any { it.startOffset == startCursor && it.endOffset == endCursor } && diagnosticTypes.contains(diagnostic.factory.name)
+    diagnostic.textRanges.any { it.startOffset <= startCursor && it.endOffset >= endCursor } && diagnosticTypes.contains(diagnostic.factory.name)
 
 fun findDiagnosticMatch(diagnostics: List<Diagnostic>, range: Range, diagnosticTypes: Set<String>) =
     diagnostics.find { diagnosticMatch(it, range, diagnosticTypes) }

--- a/server/src/main/kotlin/org/javacs/kt/util/RangeUtils.kt
+++ b/server/src/main/kotlin/org/javacs/kt/util/RangeUtils.kt
@@ -1,0 +1,8 @@
+package org.javacs.kt.util
+
+import org.eclipse.lsp4j.Range
+
+// checks if the current range is within the other range (same lines, within the character bounds)
+fun Range.isSubrangeOf(otherRange: Range): Boolean =
+    otherRange.start.line == this.start.line && otherRange.end.line == this.end.line &&
+        otherRange.start.character <= this.start.character && otherRange.end.character >= this.end.character


### PR DESCRIPTION
Fix issue where implement abstract members code action doesn't show up if you don't mark the entire text. Happens in editors that are not VSCode. The editor I experience it in is Emacs, as discussed in #366. Might be other editors as well, as I've heard from some non-VSCode that they never see any code actions.