### PR TITLE
Implement textDocument/documentHighlight

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -87,6 +87,7 @@ class KotlinLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         serverCapabilities.documentFormattingProvider = Either.forLeft(true)
         serverCapabilities.documentRangeFormattingProvider = Either.forLeft(true)
         serverCapabilities.executeCommandProvider = ExecuteCommandOptions(ALL_COMMANDS)
+        serverCapabilities.documentHighlightProvider = Either.forLeft(true)
 
         val clientCapabilities = params.capabilities
         config.completion.snippets.enabled = clientCapabilities?.textDocument?.completion?.completionItem?.snippetSupport ?: false

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -26,6 +26,7 @@ import org.javacs.kt.util.parseURI
 import org.javacs.kt.util.describeURI
 import org.javacs.kt.util.describeURIs
 import org.javacs.kt.rename.renameSymbol
+import org.javacs.kt.highlight.documentHighlightsAt
 import org.jetbrains.kotlin.resolve.diagnostics.Diagnostics
 import java.net.URI
 import java.io.Closeable
@@ -103,8 +104,9 @@ class KotlinTextDocumentService(
         }
     }
 
-    override fun documentHighlight(position: DocumentHighlightParams): CompletableFuture<List<DocumentHighlight>> {
-        TODO("not implemented")
+    override fun documentHighlight(position: DocumentHighlightParams): CompletableFuture<List<DocumentHighlight>> = async.compute {
+        val (file, cursor) = recover(position.textDocument.uri, position.position, Recompile.NEVER)
+        documentHighlightsAt(file, cursor)
     }
 
     override fun onTypeFormatting(params: DocumentOnTypeFormattingParams): CompletableFuture<List<TextEdit>> {

--- a/server/src/main/kotlin/org/javacs/kt/highlight/DocumentHighlight.kt
+++ b/server/src/main/kotlin/org/javacs/kt/highlight/DocumentHighlight.kt
@@ -37,7 +37,7 @@ private fun findDeclarationCursorSite(
         // important
         Pair(it,
              Location("",
-                      range(file.content, it.nameIdentifier?.textRangeInParent ?: return null)))
+                      range(file.content, it.nameIdentifier?.textRange ?: return null)))
     }
 }
 

--- a/server/src/main/kotlin/org/javacs/kt/highlight/DocumentHighlight.kt
+++ b/server/src/main/kotlin/org/javacs/kt/highlight/DocumentHighlight.kt
@@ -1,0 +1,44 @@
+package org.javacs.kt.highlight
+
+import org.eclipse.lsp4j.DocumentHighlight
+import org.eclipse.lsp4j.DocumentHighlightKind
+import org.eclipse.lsp4j.Location
+import org.javacs.kt.CompiledFile
+import org.javacs.kt.position.range
+import org.javacs.kt.references.findReferencesToDeclarationInFile
+import org.javacs.kt.rename.findDeclaration
+import org.javacs.kt.util.findParent
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+
+fun documentHighlightsAt(file: CompiledFile, cursor: Int): List<DocumentHighlight> {
+    val (declaration, declarationLocation) = findDeclaration(file, cursor)
+        ?: findDeclarationCursorSite(file, cursor)
+        ?: return emptyList()
+    val references = findReferencesToDeclarationInFile(declaration, file)
+
+    return if (declaration.isInFile(file.parse)) {
+        listOf(DocumentHighlight(declarationLocation.range, DocumentHighlightKind.Text))
+    } else {
+        emptyList()
+    } + references.map { DocumentHighlight(it, DocumentHighlightKind.Text) }
+}
+
+private fun findDeclarationCursorSite(
+        file: CompiledFile,
+        cursor: Int
+): Pair<KtNamedDeclaration, Location>? {
+    // current symbol might be a declaration. This function is used as a fallback when
+    // findDeclaration fails
+    val declaration = file.elementAtPoint(cursor)?.findParent<KtNamedDeclaration>()
+
+    return declaration?.let {
+        // in this scenario we know that the declaration will be at the cursor site, so uri is not
+        // important
+        Pair(it,
+             Location("",
+                      range(file.content, it.nameIdentifier?.textRangeInParent ?: return null)))
+    }
+}
+
+private fun KtNamedDeclaration.isInFile(file: KtFile) = this.containingFile == file

--- a/server/src/main/kotlin/org/javacs/kt/rename/Rename.kt
+++ b/server/src/main/kotlin/org/javacs/kt/rename/Rename.kt
@@ -4,13 +4,10 @@ import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.javacs.kt.CompiledFile
 import org.javacs.kt.SourcePath
-import org.javacs.kt.position.location
 import org.javacs.kt.references.findReferences
-import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
-import org.jetbrains.kotlin.psi.KtNamedDeclaration
 
 fun renameSymbol(file: CompiledFile, cursor: Int, sp: SourcePath, newName: String): WorkspaceEdit? {
-    val (declaration, location) = findDeclaration(file, cursor) ?: return null
+    val (declaration, location) = file.findDeclaration(cursor) ?: return null
     return declaration.let {
         val declarationEdit = Either.forLeft<TextDocumentEdit, ResourceOperation>(TextDocumentEdit(
             VersionedTextDocumentIdentifier().apply { uri = location.uri },
@@ -25,20 +22,5 @@ fun renameSymbol(file: CompiledFile, cursor: Int, sp: SourcePath, newName: Strin
         }
 
         WorkspaceEdit(listOf(declarationEdit) + referenceEdits)
-    }
-}
-
-fun findDeclaration(file: CompiledFile, cursor: Int): Pair<KtNamedDeclaration, Location>? {
-    val (_, target) = file.referenceAtPoint(cursor) ?: return null
-    val psi = target.findPsi()
-
-    return if (psi is KtNamedDeclaration) {
-        psi.nameIdentifier?.let {
-            location(it)?.let { location ->
-                Pair(psi, location)
-            }
-        }
-    } else {
-        null
     }
 }

--- a/server/src/main/kotlin/org/javacs/kt/rename/Rename.kt
+++ b/server/src/main/kotlin/org/javacs/kt/rename/Rename.kt
@@ -28,7 +28,7 @@ fun renameSymbol(file: CompiledFile, cursor: Int, sp: SourcePath, newName: Strin
     }
 }
 
-private fun findDeclaration(file: CompiledFile, cursor: Int): Pair<KtNamedDeclaration, Location>? {
+fun findDeclaration(file: CompiledFile, cursor: Int): Pair<KtNamedDeclaration, Location>? {
     val (_, target) = file.referenceAtPoint(cursor) ?: return null
     val psi = target.findPsi()
 

--- a/server/src/test/kotlin/org/javacs/kt/DocumentHighlightTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/DocumentHighlightTest.kt
@@ -92,11 +92,27 @@ class DocumentHighlightTest : SingleFileTestFixture("highlight", "DocumentHighli
 
         assertThat(result, hasSize(2))
         val firstHighlight = result[0]
-        assertThat(firstHighlight.range, equalTo(range(13, 14, 13, 23)))
+        assertThat(firstHighlight.range, equalTo(range(13, 15, 13, 24)))
         assertThat(firstHighlight.kind, equalTo(DocumentHighlightKind.Text))
 
         val secondHighlight = result[1]
         assertThat(secondHighlight.range, equalTo(range(14, 13, 14, 22)))
+        assertThat(secondHighlight.kind, equalTo(DocumentHighlightKind.Text))
+    }
+
+    @Test
+    fun `should highlight function reference correctly`() {
+        val fileUri = workspaceRoot.resolve(file).toUri().toString()
+        val input = DocumentHighlightParams(TextDocumentIdentifier(fileUri), Position(2, 6))
+        val result = languageServer.textDocumentService.documentHighlight(input).get()
+
+        assertThat(result, hasSize(2))
+        val firstHighlight = result[0]
+        assertThat(firstHighlight.range, equalTo(range(3, 5, 3, 13)))
+        assertThat(firstHighlight.kind, equalTo(DocumentHighlightKind.Text))
+
+        val secondHighlight = result[1]
+        assertThat(secondHighlight.range, equalTo(range(15, 5, 15, 13)))
         assertThat(secondHighlight.kind, equalTo(DocumentHighlightKind.Text))
     }
 }

--- a/server/src/test/kotlin/org/javacs/kt/DocumentHighlightTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/DocumentHighlightTest.kt
@@ -1,0 +1,102 @@
+package org.javacs.kt
+
+import org.eclipse.lsp4j.DocumentHighlight
+import org.eclipse.lsp4j.DocumentHighlightKind
+import org.eclipse.lsp4j.DocumentHighlightParams
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.Position
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+class DocumentHighlightTest : SingleFileTestFixture("highlight", "DocumentHighlight.kt") {
+
+    @Test
+    fun `should highlight input to function`() {
+        val fileUri = workspaceRoot.resolve(file).toUri().toString()
+        val input = DocumentHighlightParams(TextDocumentIdentifier(fileUri), Position(4, 20))
+        val result = languageServer.textDocumentService.documentHighlight(input).get()
+
+        assertThat(result, hasSize(2))
+        val firstHighlight = result[0]
+        assertThat(firstHighlight.range, equalTo(range(3, 14, 3, 19)))
+        assertThat(firstHighlight.kind, equalTo(DocumentHighlightKind.Text))
+
+        val secondHighlight = result[1]
+        assertThat(secondHighlight.range, equalTo(range(5, 20, 5, 25)))
+        assertThat(secondHighlight.kind, equalTo(DocumentHighlightKind.Text))
+    }
+
+    @Test
+    fun `should highlight global variable`() {
+        val fileUri = workspaceRoot.resolve(file).toUri().toString()
+        val input = DocumentHighlightParams(TextDocumentIdentifier(fileUri), Position(3, 23))
+        val result = languageServer.textDocumentService.documentHighlight(input).get()
+
+        assertThat(result, hasSize(3))
+        val firstHighlight = result[0]
+        assertThat(firstHighlight.range, equalTo(range(1, 5, 1, 14)))
+        assertThat(firstHighlight.kind, equalTo(DocumentHighlightKind.Text))
+
+        val secondHighlight = result[1]
+        assertThat(secondHighlight.range, equalTo(range(4, 23, 4, 32)))
+        assertThat(secondHighlight.kind, equalTo(DocumentHighlightKind.Text))
+
+        val thirdHighlight = result[2]
+        assertThat(thirdHighlight.range, equalTo(range(8, 13, 8, 22)))
+        assertThat(thirdHighlight.kind, equalTo(DocumentHighlightKind.Text))
+    }
+
+    @Test
+    fun `should highlight global variable when marked from declaration site`() {
+        val fileUri = workspaceRoot.resolve(file).toUri().toString()
+        val input = DocumentHighlightParams(TextDocumentIdentifier(fileUri), Position(0, 6))
+        val result = languageServer.textDocumentService.documentHighlight(input).get()
+
+        assertThat(result, hasSize(3))
+        val firstHighlight = result[0]
+        assertThat(firstHighlight.range, equalTo(range(1, 5, 1, 14)))
+        assertThat(firstHighlight.kind, equalTo(DocumentHighlightKind.Text))
+
+        val secondHighlight = result[1]
+        assertThat(secondHighlight.range, equalTo(range(4, 23, 4, 32)))
+        assertThat(secondHighlight.kind, equalTo(DocumentHighlightKind.Text))
+
+        val thirdHighlight = result[2]
+        assertThat(thirdHighlight.range, equalTo(range(8, 13, 8, 22)))
+        assertThat(thirdHighlight.kind, equalTo(DocumentHighlightKind.Text))
+    }
+
+    @Test
+    fun `should highlight symbols in current file where declaration is in another file`() {
+        val fileUri = workspaceRoot.resolve(file).toUri().toString()
+        val input = DocumentHighlightParams(TextDocumentIdentifier(fileUri), Position(4, 48))
+        val result = languageServer.textDocumentService.documentHighlight(input).get()
+
+        assertThat(result, hasSize(2))
+        val firstHighlight = result[0]
+        assertThat(firstHighlight.range, equalTo(range(5, 49, 5, 67)))
+        assertThat(firstHighlight.kind, equalTo(DocumentHighlightKind.Text))
+
+        val secondHighlight = result[1]
+        assertThat(secondHighlight.range, equalTo(range(9, 13, 9, 31)))
+        assertThat(secondHighlight.kind, equalTo(DocumentHighlightKind.Text))
+    }
+    
+    @Test
+    fun `should highlight shadowed variable correctly, just show the shadowed variable`() {
+        val fileUri = workspaceRoot.resolve(file).toUri().toString()
+        val input = DocumentHighlightParams(TextDocumentIdentifier(fileUri), Position(13, 14))
+        val result = languageServer.textDocumentService.documentHighlight(input).get()
+
+        assertThat(result, hasSize(2))
+        val firstHighlight = result[0]
+        assertThat(firstHighlight.range, equalTo(range(13, 14, 13, 23)))
+        assertThat(firstHighlight.kind, equalTo(DocumentHighlightKind.Text))
+
+        val secondHighlight = result[1]
+        assertThat(secondHighlight.range, equalTo(range(14, 13, 14, 22)))
+        assertThat(secondHighlight.kind, equalTo(DocumentHighlightKind.Text))
+    }
+}

--- a/server/src/test/resources/highlight/DocumentHighlight.kt
+++ b/server/src/test/resources/highlight/DocumentHighlight.kt
@@ -10,6 +10,7 @@ fun somefunc(input: String) {
 }
 
 // test shadowing of the global variable
-fun somefunc(globalval: String) {
+fun somefunc2(globalval: String) {
     println(globalval)
+    somefunc("")
 }

--- a/server/src/test/resources/highlight/DocumentHighlight.kt
+++ b/server/src/test/resources/highlight/DocumentHighlight.kt
@@ -1,0 +1,15 @@
+val globalval = 23
+
+fun somefunc(input: String) {
+    val calculation = globalval + 1
+    val otherval = input.length + calculation + somevalinotherfile
+    
+    println(otherval)
+    println(globalval)
+    println(somevalinotherfile)
+}
+
+// test shadowing of the global variable
+fun somefunc(globalval: String) {
+    println(globalval)
+}

--- a/server/src/test/resources/highlight/OtherFile.kt
+++ b/server/src/test/resources/highlight/OtherFile.kt
@@ -1,0 +1,3 @@
+val somevalinotherfile = 42
+val otherval = somevalinotherfile
+println(somevalinotherfile)


### PR DESCRIPTION
Really missed this in the Kotlin language server after programming Rust (using rust-analyzer) for a while. Having the same variable highlighted is super useful 🙂 

Fixes #208 


## Basic info
Think I've covered most of the weird edge cases with the unit tests. Also tested manually using Emacs (lsp-mode). One example of how it looks with a global variable being highlighted (the blue'ish):
<img width="704" alt="image" src="https://user-images.githubusercontent.com/5732795/191081980-0b075557-0c91-4426-b29b-578bcda27f35.png">

...and with arguments being highlighted:
<img width="704" alt="image" src="https://user-images.githubusercontent.com/5732795/191082063-451ba32e-ad9a-4922-8d03-6d1896d605b8.png">

...and a class highlighted:
<img width="704" alt="image" src="https://user-images.githubusercontent.com/5732795/191082741-cde3895c-9685-4a80-a83a-7cedd7ba81a3.png">


I think you get the point 🙂


Tried to re-use as much existing functionality as possible to make the code small and simple. Feel free to suggest any improvements if you find any. Know we have a bit different coding styles and stuff 🙂 


## Possible edge case
One weird thing I found: Hovering builtin symbols (e.g, `println` and `Exception`) and comments seems to just mark the containing function (or the nearest class or similar symbol it is commenting). I did not find this to be much of an inconvenience, so if you don't hate it either I suggest we just keep it. Unless you have a possible solution, then I'm all ears 🙂


Looks like this:
<img width="704" alt="image" src="https://user-images.githubusercontent.com/5732795/191083157-cf495056-7598-4f7b-af2d-bb78c3cf3068.png">

..and

<img width="704" alt="image" src="https://user-images.githubusercontent.com/5732795/191083248-755f44d1-be69-4539-bb94-a16faee19feb.png">



## What is not supported (possible future work?)
- Highlighting an imported symbol from the import list and in the file. Currently nothing happens when you hover the import list. If you hover the symbol in the file, it only highlights the occurences that are not in the import-list. Unsure how to solve this.



Hope you are not tired of PRs from me 😆 