### PR TITLE
Implement support for SamWithReceiverAnnotations for Gradle Kotlin DSL scripts

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-scripting-compiler:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-scripting-jvm-host-unshaded:$kotlinVersion"
+    implementation 'org.jetbrains.kotlin:kotlin-sam-with-receiver-compiler-plugin'
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     implementation 'org.jetbrains:fernflower:1.0'
     implementation "org.jetbrains.exposed:exposed-core:$exposedVersion"


### PR DESCRIPTION
Support the `SamWithReceiverAnnotations`-annotation for the Gradle Kotlin DSL scripts (tested in `build.gradle.kts` and `settings.gradle.kts`). Found while investigating https://github.com/fwcd/vscode-kotlin/issues/107, and can probably be seen as a part 1 of the solution for that issue. Hopefully also fixes #216 (the package name problem from that issue seems to have been resolved in the codebase).

Getting a simple project to verify this error and fix (before and after this PR) is to create a project with `gradle init --type kotlin-application --dsl kotlin`, and then open `app/build.gradle.kts`. Before this PR the body of application, `mainClass`, will report an error. After this fix, you can verify that `mainClass` is part of the this-scope inside the application-block. No error is reported, and `mainClass` completes successfully (together with `mainClassName` and other members). You can also complete `this.mainClass` if you are still paranoid 😛 (before it would complete using function/it-scope, which was wrong).


The reason for not using `SamWithReceiverComponentRegistrar` directly is that it wouldn't work when I tested. When reading the source code, it seems that it expects to read from some CLI inputs that the current `ScriptDefinition`/`KotlinScriptDefinitionFromAnnotatedTemplate`-based implementation does not populate. Therefore I call the internal method of the SamWithReceiverAnnotations handler directly.


Let me know if you find any potential issues. So far it has worked perfectly where I have tested it. Also doesn't seem to f**k up existing non-Gradle projects 😛