### PR TITLE
Make settings.gradle.kts scripts use the KotlinSettingsScript template

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
+++ b/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
@@ -140,6 +140,15 @@ private class CompilationEnvironment(
                             scriptClassLoader.loadClass(it).kotlin,
                             scriptHostConfig[ScriptingHostConfiguration.getEnvironment]?.invoke()
                         ) {
+                            override fun isScript(fileName: String): Boolean {
+                                // The pattern for KotlinSettingsScript doesn't seem to work well, so kinda "forcing it" for settings.gradle.kts files
+                                if (this.template.simpleName == "KotlinSettingsScript" && fileName.endsWith("settings.gradle.kts")) {
+                                    return true
+                                }
+
+                                return super.isScript(fileName)
+                            }
+
                             override val dependencyResolver: DependenciesResolver = object : DependenciesResolver {
                                 override fun resolve(scriptContents: ScriptContents, environment: Environment) = ResolveResult.Success(ScriptDependencies(
                                     imports = listOf(


### PR DESCRIPTION
Currently, a `settings.gradle.kts` file uses the KotlinBuildScript template. This causes errors in the file. Settings files (`settings.gradle.kts`) works on `org.gradle.api.initialization.Settings` classes, while Build files (`build.gradle.kts`) work on `org.gradle.api.Project` classes. These return different objects, one example being `rootProject`. This object is a `ProjectDescriptor` (having both getter and setter of names and more) in `Settings`, while it is a `Project` in the `Project` class (having only a getter for name). These highlight some of the differences in responsibilities for the two classes.


The issue can be verified by looking at the log-statement produced by the `compileKtFiles`-method in [Compiler.kt](https://github.com/fwcd/kotlin-language-server/blob/86fd15d70b99d34cef55bf1ca9b0f3401a4a79b5/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt#L499) (in our language server). For an example project (created with `gradle init --type kotlin-application --dsl kotlin`) you can notice the following:
```
KtFile: /..../testproj/settings.gradle.kts -> ScriptDefinition: KotlinBuildScript
KtFile: /..../testproj/app/build.gradle.kts -> ScriptDefinition: KotlinBuildScript
```

After this PR:
```
KtFile: /..../testproj/settings.gradle.kts -> ScriptDefinition: KotlinSettingsScript
KtFile: /..../testproj/app/build.gradle.kts -> ScriptDefinition: KotlinBuildScript
```

I have tried to find the reason that the `scriptFilePattern` in the `ScriptTemplateDefinition` doesn't work, but to no avail. When investigating and verifying with a regex-visualizer, I could not find a reason for it not to work. That is the reason for making a tiny hack like in this PR. Don't think it's a big sacrifice either, as the Gradle Kotlin DSL settings script will probably be `settings.gradle.kts` at least 99 % of the times. It will also improve the user experience (like in https://github.com/fwcd/kotlin-language-server/issues/397) to have this working instead of giving errors 🙂 



Together with #394, this PR should fix the issues mentioned in https://github.com/fwcd/kotlin-language-server/issues/397 . Depending on which of the two PRs gets merged first, I will do a rebase on the other one 🙂 