### PR TITLE
The handling of workspace folder changes has been standardized by swi…

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -147,17 +147,6 @@ class KotlinWorkspaceService(
     }
 
     override fun didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams) {
-        for (change in params.event.added) {
-            LOG.info("Adding workspace {} to source path", change.uri)
-
-            val root = Paths.get(parseURI(change.uri))
-
-            sf.addWorkspaceRoot(root)
-            val refreshed = cp.addWorkspaceRoot(root)
-            if (refreshed) {
-                sp.refresh()
-            }
-        }
         for (change in params.event.removed) {
             LOG.info("Dropping workspace {} from source path", change.uri)
 
@@ -165,6 +154,17 @@ class KotlinWorkspaceService(
 
             sf.removeWorkspaceRoot(root)
             val refreshed = cp.removeWorkspaceRoot(root)
+            if (refreshed) {
+                sp.refresh()
+            }
+        }
+        for (change in params.event.added) {
+            LOG.info("Adding workspace {} to source path", change.uri)
+
+            val root = Paths.get(parseURI(change.uri))
+
+            sf.addWorkspaceRoot(root)
+            val refreshed = cp.addWorkspaceRoot(root)
             if (refreshed) {
                 sp.refresh()
             }


### PR DESCRIPTION
While integrating with Monaco Editor, I ran into a problem.
Send both add and remove requests for the same workspace folder uri in order to add workspace folders.
Then I realized that only Kotlin LS had this problem, which is brought on by handling operation orders, therefore I tested other language servers. 

|Programming Language|Language Server|WorkspaceFolder Opration Order| Reference|
|-------------|-------------|-------------|-------------|
|Python|[pyright](https://github.com/microsoft/pyright)|Remove -> Add|https://github.com/microsoft/pyright/blob/50e12b4bea4fcdb61d96f855ca1e430bb8b41ca8/packages/pyright-internal/src/languageServerBase.ts#L648|
|C#|[omnisharp-roslyn](https://github.com/OmniSharp/omnisharp-roslyn)|Remove -> Add|https://github.com/OmniSharp/omnisharp-roslyn/blob/ff21ac475cdf8afb15579f2b5fb346945db2a7e9/src/OmniSharp.Roslyn/ProjectEventForwarder.cs#L60|
|Java|[eclipse.jdt.ls](https://github.com/eclipse/eclipse.jdt.ls)|Remove -> Add|https://github.com/eclipse/eclipse.jdt.ls/blob/64b15c5a9e5b11f62ceb5163ceb6930d5dea7129/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceFolderChangeHandler.java#L58|
|C/C++|[ccls](https://github.com/MaskRay/ccls)|Remove -> Add|https://github.com/MaskRay/ccls/blob/c6686be382da46baed4245c7963f07964575e90c/src/messages/workspace.cc#L69|
|Swift|[sourcekit-lsp](https://github.com/apple/sourcekit-lsp)|Remove -> Add|https://github.com/apple/sourcekit-lsp/blob/6081a2e50247e47313c1b45ea291db189e8ff5d7/Sources/SourceKitLSP/SourceKitServer.swift#L913|
|Kotlin|[kotlin-language-server](https://github.com/fwcd/kotlin-language-server)|Add -> Remove|https://github.com/fwcd/kotlin-language-server/blob/7cec062e38d798a0dd192e593fb76501ea538a52/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt#L150|