### PR TITLE
Upgrade to kotlin 1.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=1.3.2
-kotlinVersion=1.8.0
+kotlinVersion=1.8.10
 exposedVersion=0.37.3
 lsp4jVersion=0.15.0
 javaVersion=11

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=1.3.2
-kotlinVersion=1.6.10
+kotlinVersion=1.8.0
 exposedVersion=0.37.3
 lsp4jVersion=0.15.0
 javaVersion=11

--- a/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
+++ b/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
@@ -1,3 +1,6 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+@file:Suppress("DEPRECATION")
+
 package org.javacs.kt.compiler
 
 import com.intellij.lang.Language
@@ -67,6 +70,8 @@ import org.jetbrains.kotlin.cli.jvm.compiler.CliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.cli.jvm.config.configureJdkClasspathRoots
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.resolve.scopes.LexicalScope
 import org.jetbrains.kotlin.samWithReceiver.CliSamWithReceiverComponentContributor
@@ -110,6 +115,9 @@ private class CompilationEnvironment(
                 put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, LoggingMessageCollector)
                 add(ComponentRegistrar.PLUGIN_COMPONENT_REGISTRARS, ScriptingCompilerConfigurationComponentRegistrar())
                 put(JVMConfigurationKeys.USE_PSI_CLASS_FILES_READING, true)
+
+                // configure jvm runtime classpaths
+                configureJdkClasspathRoots()
 
                 addJvmClasspathRoots(classPath.map { it.toFile() })
                 addJavaSourceRoots(javaSourcePath.map { it.toFile() })

--- a/server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt
+++ b/server/src/main/kotlin/org/javacs/kt/completion/RenderCompletionItem.kt
@@ -9,20 +9,13 @@ import org.jetbrains.kotlin.builtins.isFunctionType
 import org.jetbrains.kotlin.renderer.ClassifierNamePolicy
 import org.jetbrains.kotlin.renderer.DescriptorRenderer
 import org.jetbrains.kotlin.renderer.ParameterNameRenderingPolicy
-import org.jetbrains.kotlin.types.ErrorUtils
-import org.jetbrains.kotlin.types.UnresolvedType
 
 val DECL_RENDERER = DescriptorRenderer.withOptions {
     withDefinedIn = false
     modifiers = emptySet()
     classifierNamePolicy = ClassifierNamePolicy.SHORT
     parameterNameRenderingPolicy = ParameterNameRenderingPolicy.ONLY_NON_SYNTHESIZED
-    typeNormalizer = {
-        when (it) {
-            is UnresolvedType ->  ErrorUtils.createErrorTypeWithCustomDebugName(it.presentableName)
-            else -> it
-        }
-    }
+    typeNormalizer = { it -> it }
 }
 
 private val GOOD_IDENTIFIER = Regex("[a-zA-Z]\\w*")

--- a/server/src/main/kotlin/org/javacs/kt/hover/Hovers.kt
+++ b/server/src/main/kotlin/org/javacs/kt/hover/Hovers.kt
@@ -20,6 +20,7 @@ import org.javacs.kt.completion.DECL_RENDERER
 import org.javacs.kt.position.position
 import org.javacs.kt.util.findParent
 import org.javacs.kt.signaturehelp.getDocString
+import org.jetbrains.kotlin.utils.IDEAPluginsCompatibilityAPI
 
 fun hoverAt(file: CompiledFile, cursor: Int): Hover? {
     val (ref, target) = file.referenceAtPoint(cursor) ?: return typeHoverAt(file, cursor)
@@ -67,6 +68,7 @@ private fun renderJavaDoc(text: String): String {
     }.joinToString("\n")
 }
 
+@OptIn(IDEAPluginsCompatibilityAPI::class)
 private fun renderTypeOf(element: KtExpression, bindingContext: BindingContext): String? {
     if (element is KtCallableDeclaration) {
         val descriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, element]

--- a/server/src/test/kotlin/org/javacs/kt/OneFilePerformance.kt
+++ b/server/src/test/kotlin/org/javacs/kt/OneFilePerformance.kt
@@ -19,8 +19,8 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.resolve.BindingTraceContext
 import org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer
 import org.jetbrains.kotlin.resolve.TopDownAnalysisMode
-import org.jetbrains.kotlin.resolve.calls.callUtil.getParentResolvedCall
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowInfoFactory
+import org.jetbrains.kotlin.resolve.calls.util.getParentResolvedCall
 import org.junit.Test
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.runner.Runner


### PR DESCRIPTION
Upgrade to kotlin 1.8.0

Seems we still cannot remove usage of deprecated ComponentRegistar at the moment, So added suppression for now which we can handle in 1.9.0 if the `org.jetbrains.kotlin.compiler.plugin.K2PluginRegistrar` is introduced as mentioned in https://youtrack.jetbrains.com/issue/KT-52665