### PR TITLE
Wrap built-in symbols in package names with backticks when auto-importing

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/imports/Imports.kt
+++ b/server/src/main/kotlin/org/javacs/kt/imports/Imports.kt
@@ -3,6 +3,8 @@ package org.javacs.kt.imports
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextEdit
+import org.jetbrains.kotlin.lexer.KtKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.*
 import org.javacs.kt.position.location
@@ -15,7 +17,7 @@ fun getImportTextEditEntry(parsedFile: KtFile, fqName: FqName): TextEdit {
     
     val pos = findImportInsertionPosition(parsedFile, fqName)
     val prefix = if (importedNames.isEmpty()) "\n\n" else "\n"
-    return TextEdit(Range(pos, pos), "${prefix}import ${fqName}")
+    return TextEdit(Range(pos, pos), "${prefix}import ${backtickBultins(fqName)}")
 }
 
 /** Finds a good insertion position for a new import of the given fully-qualified name. */
@@ -36,3 +38,25 @@ private fun matchingPrefixLength(left: FqName, right: FqName): Int =
     left.pathSegments().asSequence().zip(right.pathSegments().asSequence())
         .takeWhile { it.first == it.second }
         .count()
+
+private fun backtickBultins(fqName: FqName): String {
+    val builtInKeywords = (KtTokens.SOFT_KEYWORDS.getTypes() + KtTokens.KEYWORDS.getTypes())
+        .asSequence()
+        .mapNotNull { (it as? KtKeywordToken)?.value }
+    var result = fqName.asString()
+    for (builtin in builtInKeywords) {
+        if (result.contains(builtin)) {
+            // need to go through each part to handle words
+            // that are part of other words (e.g, as and class)
+            result = result.split('.').map {
+                if (builtin == it) {
+                    "`$builtin`"
+                } else {
+                    it
+                }
+            }.joinToString(".")
+        }
+    }
+
+    return result
+}

--- a/server/src/test/kotlin/org/javacs/kt/ImportsTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/ImportsTest.kt
@@ -1,0 +1,50 @@
+package org.javacs.kt
+
+import org.javacs.kt.imports.getImportTextEditEntry
+import org.jetbrains.kotlin.name.FqName
+import org.hamcrest.Matchers.*
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+class ImportTextEditTest : SingleFileTestFixture("imports", "Simple.kt") {
+
+    @Test
+    fun `should return normal import name`() {
+        val ktFile = languageServer.sourcePath.parsedFile(workspaceRoot.resolve(file).toUri())
+        val importName = FqName("org.jetbrains.kotlin.name.FqName")
+        val result = getImportTextEditEntry(ktFile, importName)
+
+        assertThat(result.range, equalTo(range(1, 23, 1, 23)))
+        assertThat(result.newText, equalTo("\n\nimport org.jetbrains.kotlin.name.FqName"))
+    }
+
+    @Test
+    fun `should wrap -class- in backticks`() {
+        val ktFile = languageServer.sourcePath.parsedFile(workspaceRoot.resolve(file).toUri())
+        val importName = FqName("com.class.myMethod")
+        val result = getImportTextEditEntry(ktFile, importName)
+
+        assertThat(result.range, equalTo(range(1, 23, 1, 23)))
+        assertThat(result.newText, equalTo("\n\nimport com.`class`.myMethod"))
+    }
+
+    @Test
+    fun `should wrap -fun- in backticks`() {
+        val ktFile = languageServer.sourcePath.parsedFile(workspaceRoot.resolve(file).toUri())
+        val importName = FqName("com.fun.myMethod")
+        val result = getImportTextEditEntry(ktFile, importName)
+
+        assertThat(result.range, equalTo(range(1, 23, 1, 23)))
+        assertThat(result.newText, equalTo("\n\nimport com.`fun`.myMethod"))
+    }
+
+    @Test
+    fun `should wrap multiple built in keywords in backticks`() {
+        val ktFile = languageServer.sourcePath.parsedFile(workspaceRoot.resolve(file).toUri())
+        val importName = FqName("fun.class.someother.package.method.var.val")
+        val result = getImportTextEditEntry(ktFile, importName)
+
+        assertThat(result.range, equalTo(range(1, 23, 1, 23)))
+        assertThat(result.newText, equalTo("\n\nimport `fun`.`class`.someother.`package`.method.`var`.`val`"))
+    }
+}

--- a/server/src/test/resources/imports/Simple.kt
+++ b/server/src/test/resources/imports/Simple.kt
@@ -1,0 +1,4 @@
+package test.mypackage
+
+
+val something = 1


### PR DESCRIPTION
Like the title says.
Fixes #396 


This applies when using the Add missing import quickfix/code action, and when completing a symbol that needs an additional import. It does NOT apply when completing package names in import statements (e.g, `com.c` will still complete to `com.class` and not the backticked version). The reason is that I'm unsure on how we should implement that in the best way. As I see it now, it will require a rewrite of the completion logic for package names. Please let me know if you have a suggestion for how to best implement it, as I might just be a little slow after a week of work (++ other stuff) 🙂 