### PR TITLE
Fix gradle deprecation warnings

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -20,7 +20,7 @@ val serverMainClassName = "org.javacs.kt.MainKt"
 val applicationName = "kotlin-language-server"
 
 application {
-    mainClassName = serverMainClassName
+    mainClass.set(serverMainClassName)
     description = "Code completions, diagnostics and more for Kotlin"
     applicationDefaultJvmArgs = listOf("-DkotlinLanguageServer.version=$projectVersion")
     applicationDistribution.into("bin") {


### PR DESCRIPTION
Just a small commit to fix the only deprecation warning in Gradle. By doing this, we'll be able to bump Gradle to 8+ smoothly.