### PR TITLE
Set javaVersion property in pipeline/workflow to avoid warnings on Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
           java-version: ${{ matrix.java }}
       - uses: gradle/gradle-build-action@v2
       - name: Build
-        run: ./gradlew :server:build :shared:build
+        run: ./gradlew :server:build :shared:build -PjavaVersion=${{ matrix.java }}


### PR DESCRIPTION
In the pipeline we get the following deprecation warning when running on Java 17:
```
'compileTestJava' task (current target is 17) and 'compileTestKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version.
By default will become an error since Gradle 8.0+! Read more: https://kotl.in/gradle/jvm/target-validation
Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```

In this PR we set the Java version to the same version as the pipeline is running. This should make it easy to upgrade to Gradle 8.0. @RenFraser , please let me know if you know of a better way to do this! You seem way more knowledgable on Gradle than me 🙂 