### PR TITLE
Run build pipeline on both Windows, Ubuntu and Mac OS X

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         java: [ '11', '17' ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         java: [ '11', '17' ]
     steps:
       - uses: actions/checkout@v3

--- a/server/src/main/kotlin/org/javacs/kt/resolve/ResolveMain.kt
+++ b/server/src/main/kotlin/org/javacs/kt/resolve/ResolveMain.kt
@@ -15,7 +15,12 @@ fun resolveMain(file: CompiledFile): Map<String,Any> {
 
     findTopLevelMainFunction(parsedFile)?.let { mainFunction ->
         // the KtFiles name is weird. Full path. This causes the class to have full path in name as well. Correcting to top level only
-        parsedFile.name = parsedFile.name.partitionAroundLast("/").second.substring(1)
+        parsedFile.name = if (parsedFile.name.contains("/")) {
+            parsedFile.name.partitionAroundLast("/").second.substring(1)
+        } else {
+            // assuming we are on windows
+            parsedFile.name.partitionAroundLast("\\").second.substring(1)
+        }
 
         return mapOf(
             "mainClass" to JvmFileClassUtil.getFileClassInfoNoResolve(parsedFile).facadeClassFqName.asString(),

--- a/server/src/main/kotlin/org/javacs/kt/resolve/ResolveMain.kt
+++ b/server/src/main/kotlin/org/javacs/kt/resolve/ResolveMain.kt
@@ -1,5 +1,6 @@
 package org.javacs.kt.resolve
 
+import java.io.File
 import org.jetbrains.kotlin.fileClasses.JvmFileClassUtil
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -15,12 +16,7 @@ fun resolveMain(file: CompiledFile): Map<String,Any> {
 
     findTopLevelMainFunction(parsedFile)?.let { mainFunction ->
         // the KtFiles name is weird. Full path. This causes the class to have full path in name as well. Correcting to top level only
-        parsedFile.name = if (parsedFile.name.contains("/")) {
-            parsedFile.name.partitionAroundLast("/").second.substring(1)
-        } else {
-            // assuming we are on windows
-            parsedFile.name.partitionAroundLast("\\").second.substring(1)
-        }
+        parsedFile.name = parsedFile.name.partitionAroundLast(File.separator).second.substring(1)
 
         return mapOf(
             "mainClass" to JvmFileClassUtil.getFileClassInfoNoResolve(parsedFile).facadeClassFqName.asString(),


### PR DESCRIPTION
Why? According to #430 , it seems like there are some caveats for Windows with the language server. I suggest we run the pipeline for both Windows and Ubuntu to combat this. Then we can verify that we don't break anything for Windows (e.g, paths in the shared module and similar). I know that a lot of us uses Linux and Mac OS X instead, and may therefore not have access to Windows machines (I most certainly don't), so having it in the pipeline might help.


The idea behind this PR is also to fix any errors that might happen. 


EDIT: Also added Mac OS X. Building on all major platforms will provide confidence for our users that our language server does indeed build on all major systems. We have had some issues reported with build issues on local machines, so having it in our pipeline can provide some confidence that it actually works.