### PR TITLE
Remove detekt configuration duplication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,14 +72,11 @@ tasks.register<DetektCreateBaselineTask>("createDetektBaseline") {
 }
 
 tasks.withType<Detekt>().configureEach {
+    jvmTarget = JavaVersion.VERSION_11.toString()
     reports {
         html.required.set(true)
         md.required.set(true)
     }
-}
-
-tasks.withType<Detekt>().configureEach {
-    jvmTarget = "11"
 }
 
 tasks.check.get().dependsOn(tasks.detekt)


### PR DESCRIPTION
I'd noticed that we're configuring detekt twice. 
This commit just keeps the configuration in the one place and also uses better typing for the java version that we pass to the detekt config.