### PR TITLE
Remove redundant gradle-build-action step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Build
         run: ./gradlew :server:build :shared:build -PjavaVersion=${{ matrix.java }}
-      - uses: gradle/gradle-build-action@v2
       - name: Detekt
         run: ./gradlew detekt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Build distribution
         run: ./gradlew :server:distZip :grammars:distZip
       - name: Create release


### PR DESCRIPTION
Also add a name to clarify that this is only setup. This should resolve the discussion in https://github.com/fwcd/kotlin-language-server/pull/422#discussion_r1122312120.