### PR TITLE
Create a DB index on Symbols table to make searching the SymbolIndex (H2) slightly less memory intensive

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
+++ b/server/src/main/kotlin/org/javacs/kt/index/SymbolIndex.kt
@@ -26,6 +26,8 @@ private object Symbols : IntIdTable() {
     val visibility = integer("visibility")
     val extensionReceiverType = varchar("extensionreceivertype", length = MAX_FQNAME_LENGTH).nullable()
     val location = optReference("location", Locations)
+
+    val byShortName = index("symbol_shortname_index", false, shortName)
 }
 
 private object Locations : IntIdTable() {


### PR DESCRIPTION
Doing some profiling and monitoring of the language server with VisualVM these days after several OOM issues. I discovered that when doing completions or other operations querying the symbol index, we get small spikes in heap usage. (will probably be bigger depending on the project size, number of dependencies etc.). These are probably due to having to search the entire in-memory database to find the elements. My idea is to make this slightly more effective by tuning our H2 usage, and I usually tune smaller DBs with an index or two. We search the database on `shortName`, so for me it makes sense to index on that field. My investigations by looking at the memory monitor in VisualVM seems to confirm my hypothesis, as the spikes are way smaller. 


Part one of some tuning. Might be related slightly to #352. Unsure on how much of an impact it will have on issues like #441. An on-disk index will probably improve things way more.


Having `-XX:+UseParallelGC` on seems to also improve the heap size issue slightly on my machine, but sceptical on introducing that as a default in the codebase. (mostly due to way more cpu load)