### PR TITLE
Add a troubleshooting section in TROUBLESHOOTING.md for memory issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Any editor conforming to LSP is supported, including [VSCode](https://github.com
 
 * See [BUILDING.md](BUILDING.md) for build instructions
 * See [Editor Integration](EDITORS.md) for editor-specific instructions
+* See [Troubleshooting](TROUBLESHOOTING.md) for tips on troubleshooting errors
 * See [Roadmap](https://github.com/fwcd/kotlin-language-server/projects/1) for features, planned additions, bugfixes and changes
 * See [Kotlin Quick Start](https://github.com/fwcd/kotlin-quick-start) for a sample project
 * See [Kotlin Debug Adapter](https://github.com/fwcd/kotlin-debug-adapter) for debugging support on JVM
@@ -106,16 +107,6 @@ The Kotlin language server supports some non-standard requests through LSP. See 
 
 ### Global symbols
 ![Global symbols](images/GlobalSymbols.png)
-
-## Troubleshooting
-### java.lang.OutOfMemoryError
-The language server is currently a memory hog, mostly due to its use of an in-memory database for symbols (ALL symbols from dependencies etc.!). This makes it not work well for machines with little RAM. If you experience out of memory issues, and still have lots of RAM, the default heap space might be too low. You might want to try tweaking the maximum heap space setting by setting `-Xmx8g` (which sets the heap size to 8GB. Change the number to your needs). This can be done by setting the `JAVA_OPTS` environment variable. 
-
-
-In [the VSCode extension](https://github.com/fwcd/vscode-kotlin), this is in the extension settings in the setting `Kotlin > Java: Opts`. 
-
-
-If you use Emacs, you can try the `setenv` function to set environment variables. Example: `(setenv "JAVA_OPTS" "-Xmx8g")`.
 
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ The Kotlin language server supports some non-standard requests through LSP. See 
 ### Global symbols
 ![Global symbols](images/GlobalSymbols.png)
 
+## Troubleshooting
+### java.lang.OutOfMemoryError
+The language server is currently a memory hog, mostly due to its use of an in-memory database for symbols (ALL symbols from dependencies etc.!). This makes it not work well for machines with little RAM. If you experience out of memory issues, and still have lots of RAM, the default heap space might be too low. You might want to try tweaking the maximum heap space setting by setting `-Xmx8g` (which sets the heap size to 8GB. Change the number to your needs). This can be done by setting the `JAVA_OPTS` environment variable. 
+
+
+In [the VSCode extension](https://github.com/fwcd/vscode-kotlin), this is in the extension settings in the setting `Kotlin > Java: Opts`. 
+
+
+If you use Emacs, you can try the `setenv` function to set environment variables. Example: `(setenv "JAVA_OPTS" "-Xmx8g")`.
+
+
 ## Authors
 * [georgewfraser](https://github.com/georgewfraser)
 * [fwcd](https://github.com/fwcd)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -32,3 +32,13 @@ error TS6059: File '.../KotlinLanguageServer/bin/vscode-extension-src/...' is no
 ```
 
 delete the `bin` folder in the repository directory.
+
+
+## java.lang.OutOfMemoryError when running language server
+The language server is currently a memory hog, mostly due to its use of an in-memory database for symbols (ALL symbols from dependencies etc.!). This makes it not work well for machines with little RAM. If you experience out of memory issues, and still have lots of RAM, the default heap space might be too low. You might want to try tweaking the maximum heap space setting by setting `-Xmx8g` (which sets the heap size to 8GB. Change the number to your needs). This can be done by setting the `JAVA_OPTS` environment variable. 
+
+
+In [the VSCode extension](https://github.com/fwcd/vscode-kotlin), this is in the extension settings in the setting `Kotlin > Java: Opts`. 
+
+
+If you use Emacs, you can try the `setenv` function to set environment variables. Example: `(setenv "JAVA_OPTS" "-Xmx8g")`.


### PR DESCRIPTION
Several people have been experiencing memory issues with the language server for their projects. While this PR doesn't fix anything, I think it can be useful to point people to something they can try to possibly fix the issues on their machines. Therefore I suggest adding a troubleshooting section to the README so it is visible somewhere. Feel free to suggest a better place 🙂 

The vscode description depends on https://github.com/fwcd/vscode-kotlin/pull/121


Issues: #441, https://github.com/fwcd/vscode-kotlin/issues/120 , #403. 