### PR TITLE
Add support for unsigned integer literals

### DIFF
--- a/grammars/Kotlin.tmLanguage.json
+++ b/grammars/Kotlin.tmLanguage.json
@@ -503,11 +503,11 @@
             ]
         },
         "decimal-literal": {
-            "match": "\\b\\d[\\d_]*(\\.[\\d_]+)?((e|E)\\d+)?(L|F|f)?\\b",
+            "match": "\\b\\d[\\d_]*(\\.[\\d_]+)?((e|E)\\d+)?(u|U)?(L|F|f)?\\b",
             "name": "constant.numeric.decimal.kotlin"
         },
         "hex-literal": {
-            "match": "0(x|X)[A-Fa-f0-9][A-Fa-f0-9_]*",
+            "match": "0(x|X)[A-Fa-f0-9][A-Fa-f0-9_]*(u|U)?",
             "name": "constant.numeric.hex.kotlin"
         },
         "binary-literal": {


### PR DESCRIPTION
This should add support for unsigned integer literals in the syntax grammar eg:

```kotlin
val b: UByte = 1u  // UByte, expected type provided
val s: UShort = 1u // UShort, expected type provided
val l: ULong = 1u  // ULong, expected type provided

val a1 = 42u // UInt: no expected type provided, constant fits in UInt
val a2 = 0xFFFF_FFFF_FFFFu // ULong: no expected type provided, constant

val a = 1UL // ULong, even though no expected type provided and constant fits into UInt
```

(https://kotlinlang.org/docs/unsigned-integer-types.html#unsigned-integers-literals)

Before (ignore error underlines, that is something else):
![image](https://user-images.githubusercontent.com/150152/231190001-028d453d-0db4-4945-8963-b59f41293d48.png)

After:
![image](https://user-images.githubusercontent.com/150152/231190110-1ee5e6b7-9067-4db5-8668-05f9ea43e9a9.png)
