### PR TITLE
Only backtick hard keywords in imports

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/imports/Imports.kt
+++ b/server/src/main/kotlin/org/javacs/kt/imports/Imports.kt
@@ -40,8 +40,7 @@ private fun matchingPrefixLength(left: FqName, right: FqName): Int =
         .count()
 
 private fun backtickBultins(fqName: FqName): String {
-    val builtInKeywords = (KtTokens.SOFT_KEYWORDS.getTypes() + KtTokens.KEYWORDS.getTypes())
-        .asSequence()
+    val builtInKeywords = KtTokens.KEYWORDS.getTypes()
         .mapNotNull { (it as? KtKeywordToken)?.value }
     var result = fqName.asString()
     for (builtin in builtInKeywords) {

--- a/server/src/test/kotlin/org/javacs/kt/ImportsTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/ImportsTest.kt
@@ -47,4 +47,17 @@ class ImportTextEditTest : SingleFileTestFixture("imports", "Simple.kt") {
         assertThat(result.range, equalTo(range(1, 23, 1, 23)))
         assertThat(result.newText, equalTo("\n\nimport `fun`.`class`.someother.`package`.method.`var`.`val`"))
     }
+
+    @Test
+    fun `should NOT wrap soft keywords or modifiers in backticks`() {
+        // tests for a selection of soft keywords and modifiers
+        // according to https://kotlinlang.org/docs/keyword-reference.html
+        //  both can be used as identifiers. (only hard keywords can not)
+        val ktFile = languageServer.sourcePath.parsedFile(workspaceRoot.resolve(file).toUri())
+        val importName = FqName("as.annotation.import.by.inner.file.field")
+        val result = getImportTextEditEntry(ktFile, importName)
+
+        assertThat(result.range, equalTo(range(1, 23, 1, 23)))
+        assertThat(result.newText, equalTo("\n\nimport `as`.annotation.import.by.inner.file.field"))
+    }
 }


### PR DESCRIPTION
When importing, we only need to backtick hard keywords. Don't backtick soft keywords and modifiers, as those can be used in package names. You can read more in [the official documentation](https://kotlinlang.org/docs/keyword-reference.html).

Example of the backticking that happens before this PR (notice the line with `PutMapping`):
<img width="445" alt="image" src="https://user-images.githubusercontent.com/5732795/231244204-c69ecf92-a3e6-4703-8dea-f93b9183e64a.png">
(not an error per se, but not needed)
