### PR TITLE
Fix injectionSelector of Kotlin markdown code block

### DIFF
--- a/grammars/codeblock.json
+++ b/grammars/codeblock.json
@@ -1,6 +1,6 @@
 {
     "fileTypes": [],
-    "injectionSelector": "L:markup.fenced_code.block.markdown",
+    "injectionSelector": "L:text.html.markdown",
     "patterns": [
         {
             "include": "#kotlin-code-block"
@@ -8,12 +8,35 @@
     ],
     "repository": {
         "kotlin-code-block": {
-            "begin": "kotlin",
-            "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
-            "contentName": "meta.embedded.block.kotlin",
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(kotlin)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
             "patterns": [
                 {
-                    "include": "source.kotlin"
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.kotlin",
+                    "patterns": [
+                        {
+                            "include": "source.kotlin"
+                        }
+                    ]
                 }
             ]
         }

--- a/grammars/vscode-grammar-dev/package.json
+++ b/grammars/vscode-grammar-dev/package.json
@@ -10,16 +10,36 @@
         "Programming Languages"
     ],
     "contributes": {
-        "languages": [{
-            "id": "kotlin",
-            "aliases": ["Kotlin", "kotlin"],
-            "extensions": [".kt",".kts"],
-            "configuration": "../kotlin.configuration.json"
-        }],
-        "grammars": [{
-            "language": "kotlin",
-            "scopeName": "source.kotlin",
-            "path": "../Kotlin.tmLanguage.json"
-        }]
+        "languages": [
+            {
+                "id": "kotlin",
+                "aliases": [
+                    "Kotlin",
+                    "kotlin"
+                ],
+                "extensions": [
+                    ".kt",
+                    ".kts"
+                ],
+                "configuration": "../kotlin.configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "kotlin",
+                "scopeName": "source.kotlin",
+                "path": "../Kotlin.tmLanguage.json"
+            },
+            {
+                "scopeName": "markdown.kotlin.codeblock",
+                "path": "../codeblock.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.kotlin": "kotlin"
+                }
+            }
+        ]
     }
 }


### PR DESCRIPTION
Previously the Kotlin language grammar was injected to `L:markup.fenced_code.block.markdown`, causing the following incorrect rendering of other code blocks in VSCode:

![image](https://github.com/fwcd/kotlin-language-server/assets/4702188/4f7f63c4-79e7-4285-98dd-e46580d03067)

The selector should be changed to a more restricted one of `L:markup.fenced_code.block.markdown - meta.embedded.block`.

Downstream project [vscode-kotlin](https://github.com/fwcd/vscode-kotlin) is also affected.