### PR TITLE
Update kdoc keywords according to https://kotlinlang.org/docs/kotlin-doc.html

### DIFF
--- a/grammars/Kotlin.tmLanguage.json
+++ b/grammars/Kotlin.tmLanguage.json
@@ -173,11 +173,22 @@
                     "name": "comment.block.javadoc.kotlin",
                     "patterns": [
                         {
-                            "match": "@(author|deprecated|return|see|serial|since|version)\\b",
+                            "match": "@(return|constructor|receiver|sample|see|author|since|suppress)\\b",
                             "name": "keyword.other.documentation.javadoc.kotlin"
                         },
                         {
-                            "match": "(@param)\\s+(\\S+)",
+                            "match": "(@param|@property)\\s+(\\S+)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "variable.parameter.kotlin"
+                                }
+                            }
+                        },
+                        {
+                            "match": "(@param)\\[(\\S+)\\]",
                             "captures": {
                                 "1": {
                                     "name": "keyword.other.documentation.javadoc.kotlin"


### PR DESCRIPTION
Fixes #481

Updates the kdoc comments according to the kotlin documentation.

Removes `@deprecated` which is explicitly excluded in the documentation, as well as `@serial` and `@version` which are not listed as supported.

It then adds support for `@constructor`, `@receiver`, `@sample`, `@suppress` and `@property`.

It also supports the `@param[name]` syntax which is given as an example in the docs - no other tags are mentioned to support this name.

![image](https://github.com/fwcd/kotlin-language-server/assets/150152/d4824316-764a-4717-9a41-331b176d2f7e)
