### PR TITLE
Extract Docker build into separate workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,14 +38,6 @@ jobs:
         run: |
           tag="${{ steps.tag.outputs.tag }}"
           gh release upload "$tag" {server,grammars}/build/distributions/*
-      - name: Deploy Docker image to GitHub Packages
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: fwcd/kotlin-language-server/server
-          tag_with_ref: true
       - name: Deploy Maven artifacts to GitHub Packages
         run: ./gradlew :shared:publish :server:publish
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           images: fwcd/kotlin-language-server
       - name: Build and push image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     if: github.repository == 'fwcd/kotlin-language-server'
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Docker
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.repository == 'fwcd/kotlin-language-server'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: fwcd/kotlin-language-server
+      - name: Build and push image
+        uses: docker/build-push-action@v1
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64/v8
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.output.tags }}
+          labels: ${{ steps.meta.output.labels }}


### PR DESCRIPTION
### Fixes #347

Additionally, update to GHCR, build arm64 images, use the metadata-action to label the images and shorten the image name to `fwcd/kotlin-language-server` (dropping the `/server` suffix).