### PR TITLE
Refactor the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # Running this container will start a language server that listens for TCP connections on port 49100
 # Every connection will be run in a forked child process
 
-FROM --platform=$BUILDPLATFORM eclipse-temurin:11 AS builder
+ARG JDKVERSION=11
+
+FROM --platform=$BUILDPLATFORM eclipse-temurin:${JDKVERSION} AS builder
 
 WORKDIR /src/kotlin-language-server
 
 COPY . .
 RUN ./gradlew :server:installDist
 
-FROM eclipse-temurin:11
+FROM eclipse-temurin:${JDKVERSION}
 
 WORKDIR /opt/kotlin-language-server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Running this container will start a language server that listens for TCP connections on port 49100
+# Running this image will start a language server that listens for TCP connections on port 49100
 # Every connection will be run in a forked child process
 
 ARG JDKVERSION=11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Running this container will start a language server that listens for TCP connections on port 49100
 # Every connection will be run in a forked child process
 
-FROM openjdk:11 AS builder
+FROM eclipse-temurin:11 AS builder
 
 WORKDIR /kotlin-language-server
 COPY . .
 RUN ./gradlew :server:installDist
 
-FROM openjdk:11
+FROM eclipse-temurin:11
 
 WORKDIR /
 COPY --from=builder /kotlin-language-server/server/build/install/server /server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Running this container will start a language server that listens for TCP connections on port 49100
 # Every connection will be run in a forked child process
 
-FROM eclipse-temurin:11 AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:11 AS builder
 
 WORKDIR /src/kotlin-language-server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,18 @@
 
 FROM eclipse-temurin:11 AS builder
 
-WORKDIR /kotlin-language-server
+WORKDIR /src/kotlin-language-server
+
 COPY . .
 RUN ./gradlew :server:installDist
 
 FROM eclipse-temurin:11
 
-WORKDIR /
-COPY --from=builder /kotlin-language-server/server/build/install/server /server
+WORKDIR /opt/kotlin-language-server
+
+COPY --from=builder /src/kotlin-language-server/server/build/install/server /opt/kotlin-language-server
+RUN ln -s /opt/kotlin-language-server/bin/kotlin-language-server /usr/local/bin/kotlin-language-server
 
 EXPOSE 49100
 
-CMD ["/server/bin/kotlin-language-server", "--tcpServerPort", "49100"]
+CMD ["/usr/local/bin/kotlin-language-server", "--tcpServerPort", "49100"]


### PR DESCRIPTION
Use `eclipse-temurin` as a base image (instead of the deprecated `openjdk` image), use [Docker's `FROM --platform`](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/) to build for all architectures on the host platform and migrate to a more FHS-compliant file layout.

### Future Directions

- Investigate using `jlink` to build a minimal runtime [as described in the `eclipse-temurin` README](https://hub.docker.com/_/eclipse-temurin#:~:text=Creating%20a%20JRE%20using%20jlink)