### PR TITLE
Move platform to subproject

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -2,8 +2,6 @@ plugins {
     id("java-platform")
 }
 
-group = "dev.fwcd.kotlin-language-server"
-
 javaPlatform {
     allowDependencies()
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -34,9 +34,9 @@ repositories {
 
 dependencies {
     // dependencies are constrained to versions defined
-    // in /gradle/platform/build.gradle.kts
-    implementation(platform("dev.fwcd.kotlin-language-server:platform"))
-    annotationProcessor(platform("dev.fwcd.kotlin-language-server:platform"))
+    // in /platform/build.gradle.kts
+    implementation(platform(project(":platform")))
+    annotationProcessor(platform(project(":platform")))
 
     implementation(project(":shared"))
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,13 +26,10 @@ pluginManagement {
     }
 }
 
-dependencyResolutionManagement {
-    includeBuild("gradle/platform")
-}
-
 rootProject.name = "kotlin-language-server"
 
 include(
+    "platform",
     "shared",
     "server",
     "grammars"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -11,8 +11,8 @@ repositories {
 
 dependencies {
     // dependencies are constrained to versions defined
-    // in /gradle/platform/build.gradle.kts
-    implementation(platform("dev.fwcd.kotlin-language-server:platform"))
+    // in /platform/build.gradle.kts
+    implementation(platform(project(":platform")))
 
     implementation(kotlin("stdlib"))
     implementation("org.jetbrains.exposed:exposed-core")


### PR DESCRIPTION
The Java platform mechanism[^1] is what we use to pin dependencies across subprojects. According to the docs, the idiomatic way to share a platform is to use regular subprojects[^2], so in the spirit of making our build "more standard", we'll do so too.

[^1]: See the Gradle docs on the Java platform plugin: https://docs.gradle.org/current/userguide/java_platform_plugin.html
[^2]: See the Gradle docs on controlling transitive dependency versions: https://docs.gradle.org/current/userguide/platforms.html#sub:using-platform-to-control-transitive-deps