### PR TITLE
Add Database versioning

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
@@ -4,7 +4,10 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.nio.file.Files
 import java.nio.file.Path

--- a/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
@@ -1,23 +1,70 @@
 package org.javacs.kt.database
 
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
 import java.nio.file.Files
 import java.nio.file.Path
 
+private object DatabaseMetadata : IntIdTable() {
+    var version = integer("version")
+}
+
+class DatabaseMetadataEntity(id: EntityID<Int>) : IntEntity(id) {
+    companion object : IntEntityClass<DatabaseMetadataEntity>(DatabaseMetadata)
+
+    var version by DatabaseMetadata.version
+}
+
 class DatabaseService {
+
+    companion object {
+        const val CURRENT_VERSION = 1
+        const val DB_FILENAME = "kls_database.db"
+    }
 
     var db: Database? = null
         private set
 
     fun setup(storagePath: Path?) {
-        val dbName = "kls_database"
+        db = getDbFromFile(storagePath)
 
-        db = storagePath?.let {
+        val currentVersion = transaction(db) {
+            SchemaUtils.createMissingTablesAndColumns(DatabaseMetadata)
+
+            DatabaseMetadataEntity.all().firstOrNull()?.version
+        }
+
+        if ((currentVersion ?: 0) < CURRENT_VERSION) {
+            deleteDb(storagePath)
+
+            db = getDbFromFile(storagePath)
+
+            transaction(db) {
+                SchemaUtils.createMissingTablesAndColumns(DatabaseMetadata)
+
+                DatabaseMetadata.deleteAll()
+                DatabaseMetadata.insert { it[version] = CURRENT_VERSION }
+            }
+        }
+    }
+
+    private fun getDbFromFile(storagePath: Path?): Database? {
+        return storagePath?.let {
             if (Files.isDirectory(it)) {
-                Database.connect("jdbc:sqlite:${Path.of(storagePath.toString(), dbName)}.db")
+                Database.connect("jdbc:sqlite:${getDbFilePath(it)}")
             } else {
                 null
             }
         }
     }
+
+    private fun deleteDb(storagePath: Path?) {
+        storagePath?.let { Files.deleteIfExists(getDbFilePath(it)) }
+    }
+
+    private fun getDbFilePath(storagePath: Path) = Path.of(storagePath.toString(), DB_FILENAME)
 }


### PR DESCRIPTION
Fixes https://github.com/fwcd/kotlin-language-server/issues/503

We now have a metadata table where we store the database version. If the value stored is the same as the current version, we do nothing. Otherwise, we just delete the entire database and recreate it.

This does not solve https://github.com/fwcd/kotlin-language-server/issues/470 (we can do that in a following PR for clarity)

Note: In the next few weeks, I'll probably also add a command to the VSCode extension to delete the workspace storage directory since that can be helpful at times.
