### PR TITLE
Fix cached source jar paths

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/externalsources/ClassContentProvider.kt
+++ b/server/src/main/kotlin/org/javacs/kt/externalsources/ClassContentProvider.kt
@@ -35,10 +35,11 @@ class ClassContentProvider(
      * If the file is inside a source archive, the source code is returned as is.
      */
     fun contentOf(uri: KlsURI): Pair<KlsURI, String> {
+        LOG.info("Resolving {} for contents", uri)
         val resolvedUri = sourceArchiveProvider.fetchSourceArchive(uri.archivePath)?.let(uri.withSource(true)::withArchivePath) ?: uri
         val key = resolvedUri.toString()
         val (contents, extension) = cachedContents[key] ?: run {
-                LOG.info("Finding contents of {}", describeURI(resolvedUri.fileUri))
+                LOG.info("Reading contents of {}", describeURI(resolvedUri.fileUri))
                 tryReadContentOf(resolvedUri)
                     ?: tryReadContentOf(resolvedUri.withFileExtension("class"))
                     ?: tryReadContentOf(resolvedUri.withFileExtension("java"))

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
@@ -60,7 +60,7 @@ internal class CachedClassPathResolver(
             ClassPathCacheEntryEntity.all().map {
                 ClassPathEntry(
                     compiledJar = Paths.get(it.compiledJar),
-                    sourceJar = if (it.sourceJar != null) Paths.get(it.sourceJar) else null
+                    sourceJar = it.sourceJar?.let(Paths::get)
                 )
             }.toSet()
         }
@@ -69,7 +69,7 @@ internal class CachedClassPathResolver(
             newEntries.map {
                 ClassPathCacheEntryEntity.new {
                     compiledJar = it.compiledJar.toString()
-                    sourceJar = it.sourceJar.toString()
+                    sourceJar = it.sourceJar?.toString()
                 }
             }
         }

--- a/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
@@ -26,7 +26,7 @@ class DatabaseMetadataEntity(id: EntityID<Int>) : IntEntity(id) {
 class DatabaseService {
 
     companion object {
-        const val LATEST_VERSION = 1
+        const val LATEST_VERSION = 2
         const val DB_FILENAME = "kls_database.db"
     }
 


### PR DESCRIPTION
### Fixes #470 

This fixes an issue where `null` external source jar paths would have incorrectly been ingested into the database as the string `"null"` and break the definition lookup. See https://github.com/fwcd/kotlin-language-server/issues/470#issuecomment-1745548550 for detailed discussion.

Additionally it bumps the database version to make sure that users' databases get rebuilt with the correct paths.