### PR TITLE
Filter by path when querying `BindingContext`

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
@@ -33,8 +33,6 @@ class CompiledFile(
     val isScript: Boolean = false,
     val kind: CompilationKind = CompilationKind.DEFAULT
 ) {
-    val path: Path by lazy { parse.containingFile.toPath() }
-
     /**
      * Find the type of the expression at `cursor`
      */
@@ -72,9 +70,11 @@ class CompiledFile(
         val cursorExpr = element?.findParent<KtExpression>() ?: return nullResult("Couldn't find expression at ${describePosition(cursor)} (only found $element)")
         val surroundingExpr = expandForReference(cursor, cursorExpr)
         val scope = scopeAtPoint(cursor) ?: return nullResult("Couldn't find scope at ${describePosition(cursor)}")
+        // NOTE: Due to our tiny-fake-file mechanism, we may have `path == /dummy.virtual.kt != parse.containingFile.toPath`
+        val path = surroundingExpr.containingFile.toPath()
         val context = bindingContextOf(surroundingExpr, scope)
         LOG.info("Hovering {}", surroundingExpr)
-        return referenceFromContext(cursor, context)
+        return referenceFromContext(cursor, path, context)
     }
 
     /**
@@ -83,10 +83,11 @@ class CompiledFile(
      * This method should not be used for anything other than finding definitions (at least for now).
      */
     fun referenceExpressionAtPoint(cursor: Int): Pair<KtExpression, DeclarationDescriptor>? {
-        return referenceFromContext(cursor, compile)
+        val path = parse.containingFile.toPath()
+        return referenceFromContext(cursor, path, compile)
     }
 
-    private fun referenceFromContext(cursor: Int, context: BindingContext): Pair<KtExpression, DeclarationDescriptor>? {
+    private fun referenceFromContext(cursor: Int, path: Path, context: BindingContext): Pair<KtExpression, DeclarationDescriptor>? {
         val targets = context.getSliceContents(BindingContext.REFERENCE_TARGET)
         return targets.asSequence()
                 .filter { cursor in it.key.textRange && it.key.containingFile.toPath() == path }
@@ -224,6 +225,7 @@ class CompiledFile(
      */
     fun scopeAtPoint(cursor: Int): LexicalScope? {
         val oldCursor = oldOffset(cursor)
+        val path = parse.containingFile.toPath()
         return compile.getSliceContents(BindingContext.LEXICAL_SCOPE).asSequence()
                 .filter {
                     it.key.textRange.startOffset <= oldCursor


### PR DESCRIPTION
Our `BindingContext`s may span several files, presumably because we compile changed modules in batch and then store the same context across all of these `SourceFile`s:

https://github.com/fwcd/kotlin-language-server/blob/5aa94dad4ef2e2a56b9f6d2907feff52386cf7bf/server/src/main/kotlin/org/javacs/kt/SourcePath.kt#L221-L233

This had the unfortunate side effect that the implicit assumption (?) in methods such as `CompiledFile.referenceFromContext` or `scopeAtPoint` that all entries are in the same file (and thus that it is sufficient to filter by position within the file), does not hold:

https://github.com/fwcd/kotlin-language-server/blob/5aa94dad4ef2e2a56b9f6d2907feff52386cf7bf/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt#L86-L93

Since other files sometimes contain matching scopes, this would cause definition lookups to occasionally return bogus results since they also included elements at the same position within _other_ files.

This fixes this by checking the file path too.