### PR TITLE
Support functional interfaces in Kotlin Textmate grammar

### DIFF
--- a/grammars/Kotlin.tmLanguage.json
+++ b/grammars/Kotlin.tmLanguage.json
@@ -303,7 +303,7 @@
             "name": "entity.name.type.annotation.kotlin"
         },
         "class-declaration": {
-            "match": "\\b(class|interface)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
+            "match": "\\b(class|interface|fun\\s+interface)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
             "captures": {
                 "1": {
                     "name": "storage.type.class.kotlin"

--- a/grammars/Kotlin.tmLanguage.json
+++ b/grammars/Kotlin.tmLanguage.json
@@ -303,7 +303,7 @@
             "name": "entity.name.type.annotation.kotlin"
         },
         "class-declaration": {
-            "match": "\\b(class|interface|fun\\s+interface)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
+            "match": "\\b(class|(?:fun\\s+)?interface)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
             "captures": {
                 "1": {
                     "name": "storage.type.class.kotlin"


### PR DESCRIPTION
Slightly improve syntax highlighting of functional interfaces (see the `fun? interface` branch in the [classDeclaration](https://kotlinlang.org/docs/reference/grammar.html#classDeclaration) rule).

Before:
![before](https://github.com/fwcd/kotlin-language-server/assets/23585021/25acf89c-d0a4-4af3-b56e-d683aa5df322)

After:
![after](https://github.com/fwcd/kotlin-language-server/assets/23585021/e673933f-ed11-468d-8523-26ab4517fa89)
