### PR TITLE
Exclude test resource workspaces in detekt analysis

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -2,7 +2,17 @@ config:
   validation: true # verifies that this config file is valid
   warningsAsErrors: false
 
+comments:
+  excludes: ["**/src/test/resources/**"]
+
+complexity:
+  excludes: ["**/src/test/resources/**"]
+  
+empty-blocks:
+  excludes: ["**/src/test/resources/**"]
+  
 exceptions:
+  excludes: ["**/src/test/resources/**"]
   SwallowedException:
     ignoredExceptionTypes:
       - InterruptedException
@@ -11,6 +21,16 @@ exceptions:
       - ParseException
       - MissingPropertyException
 
+naming:
+  excludes: ["**/src/test/resources/**"]
+
+performance:
+  excludes: ["**/src/test/resources/**"]
+
+potential-bugs:
+  excludes: ["**/src/test/resources/**"]
+  
 style:
+  excludes: ["**/src/test/resources/**"]
   MaxLineLength:
     active: false


### PR DESCRIPTION
If you take a look at builds in for example #498, you will notice that the test workspaces (e.g, `server/src/test/resources/inlayhints` are affected by detekt scans. I don't think we need to hold this code to the same standard as the main codebase. Sometimes we have minor errors and similar to check that the language server behaves correctly. Detekt will pick up on this and cause issues in the builds. One could off course put this into the baseline, but I think that is a waste of effort. Others might suggest removing it... Instead I suggest we exclude these test workspaces, and keep all the awesome benefits of Detekt 🙂 


Hopefully you agree @fwcd 🙂 