### PR TITLE
Fix maven repository discovery

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
@@ -1,18 +1,28 @@
 package org.javacs.kt.classpath
 
-import org.javacs.kt.util.userHome
+import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
+import org.javacs.kt.util.KotlinLSException
+import org.javacs.kt.util.userHome
 
+private fun createPathOrNull(envVar: String): Path? {
+  return System.getenv(envVar)?.let { Paths.get(it) }
+}
 
-internal val gradleHome =
-    System.getenv("GRADLE_USER_HOME")?.let { Paths.get(it) }
-        ?: userHome.resolve(".gradle")
-
-internal val mavenHome =
-    System.getenv("MAVEN_HOME")?.let { Paths.get(it) }
-        ?: System.getenv("M2_HOME")?.let { Paths.get(it) }
-        ?: userHome.resolve(".m2")
+private val possibleMavenRepositoryPaths =
+    sequenceOf(
+            createPathOrNull("MAVEN_REPOSITORY"),
+            createPathOrNull("MAVEN_HOME")?.let { it.resolve("repository") },
+            createPathOrNull("M2_HOME")?.let { it.resolve("repository") },
+            userHome.resolve(".m2/repository"),
+        )
+        .filterNotNull()
 
 internal val mavenRepository =
-    System.getenv("MAVEN_REPOSITORY")?.let { Paths.get(it) }
-        ?: mavenHome.resolve("repository")
+    possibleMavenRepositoryPaths.firstOrNull { Files.exists(it) }
+        ?: throw KotlinLSException(
+            "No repositories found at \$MAVEN_REPOSITORY, \$MAVEN_HOME, \$M2_HOME or \$HOME/.m2"
+        )
+
+internal val gradleHome = createPathOrNull("GRADLE_USER_HOME") ?: userHome.resolve(".gradle")

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
@@ -10,12 +10,12 @@ private fun createPathOrNull(envVar: String): Path? = System.getenv(envVar)?.let
 
 private val possibleMavenRepositoryPaths =
     sequenceOf(
-            createPathOrNull("MAVEN_REPOSITORY"),
-            createPathOrNull("MAVEN_HOME")?.let { it.resolve("repository") },
-            createPathOrNull("M2_HOME")?.let { it.resolve("repository") },
-            userHome.resolve(".m2/repository"),
-        )
-        .filterNotNull()
+        createPathOrNull("MAVEN_REPOSITORY"),
+        createPathOrNull("MAVEN_HOME")?.let { it.resolve("repository") },
+        createPathOrNull("M2_HOME")?.let { it.resolve("repository") },
+        userHome.resolve(".m2/repository"),
+    )
+    .filterNotNull()
 
 internal val mavenRepository =
     possibleMavenRepositoryPaths.firstOrNull { Files.exists(it) }

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
@@ -6,9 +6,7 @@ import java.nio.file.Paths
 import org.javacs.kt.util.KotlinLSException
 import org.javacs.kt.util.userHome
 
-private fun createPathOrNull(envVar: String): Path? {
-  return System.getenv(envVar)?.let { Paths.get(it) }
-}
+private fun createPathOrNull(envVar: String): Path? = System.getenv(envVar)?.let(Paths::get)
 
 private val possibleMavenRepositoryPaths =
     sequenceOf(


### PR DESCRIPTION
Related to #430

Fixes the Maven repository discovery by checking if the candidate paths have a `/repository` directory. An exception is thrown if no valid repository paths are found. The order of discovery is maintained as before:
- `$MAVEN_REPOSITORY`
- `$MAVEN_HOME`
- `$M2_HOME`
- `$HOME/.m2`