### PR TITLE
increase the max length of varchar column of ClassPathCacheEntry table

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
@@ -12,7 +12,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import java.nio.file.Path
 import java.nio.file.Paths
 
-private const val MAX_PATH_LENGTH = 255
+private const val MAX_PATH_LENGTH = 65535
 
 private object ClassPathMetadataCache : IntIdTable() {
     val includesSources = bool("includessources")

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/CachedClassPathResolver.kt
@@ -12,7 +12,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import java.nio.file.Path
 import java.nio.file.Paths
 
-private const val MAX_PATH_LENGTH = 65535
+private const val MAX_PATH_LENGTH = 2047
 
 private object ClassPathMetadataCache : IntIdTable() {
     val includesSources = bool("includessources")

--- a/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/database/DatabaseService.kt
@@ -26,7 +26,7 @@ class DatabaseMetadataEntity(id: EntityID<Int>) : IntEntity(id) {
 class DatabaseService {
 
     companion object {
-        const val DB_VERSION = 3
+        const val DB_VERSION = 4
         const val DB_FILENAME = "kls_database.db"
     }
 


### PR DESCRIPTION
Sometimes the length of path to compiledjar may get longer than 255. 
For example, the path to the cache of this artifact https://mvnrepository.com/artifact/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.security.authorization.saf/1.3.78 may be like following: `/Users/username/.gradle/caches/modules-2/files-2.1/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.security.authorization.saf/1.3.78/5fb520b6711e772218e7f9917d51d1c4347e4cf4/com.ibm.websphere.appserver.api.security.authorization.saf-1.3.78.jar`

It might be better to make this limitation longer.