### PR TITLE
Define standard exclusion paths in Detekt configuration

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -4,6 +4,8 @@ config:
 
 comments:
   excludes: &standardExcludes
+    - '**/bin/**'
+    - '**/build/**'
     - '**/src/test/**'
 
 complexity:

--- a/detekt.yml
+++ b/detekt.yml
@@ -3,16 +3,17 @@ config:
   warningsAsErrors: false
 
 comments:
-  excludes: ["**/src/test/**"]
+  excludes: &standardExcludes
+    - '**/src/test/**'
 
 complexity:
-  excludes: ["**/src/test/**"]
+  excludes: *standardExcludes
 
 empty-blocks:
-  excludes: ["**/src/test/**"]
+  excludes: *standardExcludes
 
 exceptions:
-  excludes: ["**/src/test/**"]
+  excludes: *standardExcludes
   SwallowedException:
     ignoredExceptionTypes:
       - CancellationException
@@ -23,16 +24,16 @@ exceptions:
       - MissingPropertyException
 
 naming:
-  excludes: ["**/src/test/resources/**"]
+  excludes: *standardExcludes
 
 performance:
-  excludes: ["**/src/test/resources/**"]
+  excludes: *standardExcludes
 
 potential-bugs:
-  excludes: ["**/src/test/resources/**"]
+  excludes: *standardExcludes
 
 style:
-  excludes: ["**/src/test/resources/**"]
+  excludes: *standardExcludes
   MaxLineLength:
     active: false
   WildcardImport:


### PR DESCRIPTION
We now ignore tests in all rule sets, along with `bin` (generated by the VSCode Java extension, which uses the Eclipse JDT language server under the hood where this presumably originates from) and `build`.