### PR TITLE
Rename config object to `inlayHints` for consistency

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -101,5 +101,5 @@ public data class Configuration(
     val scripts: ScriptsConfiguration = ScriptsConfiguration(),
     val indexing: IndexingConfiguration = IndexingConfiguration(),
     val externalSources: ExternalSourcesConfiguration = ExternalSourcesConfiguration(),
-    val hints: InlayHintsConfiguration = InlayHintsConfiguration()
+    val inlayHints: InlayHintsConfiguration = InlayHintsConfiguration()
 )

--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -98,7 +98,7 @@ class KotlinTextDocumentService(
 
     override fun inlayHint(params: InlayHintParams): CompletableFuture<List<InlayHint>> = async.compute {
         val (file, _) = recover(params.textDocument.uri, params.range.start, Recompile.ALWAYS)
-        provideHints(file, config.hints)
+        provideHints(file, config.inlayHints)
     }
 
     override fun hover(position: HoverParams): CompletableFuture<Hover?> = async.compute {

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -105,10 +105,10 @@ class KotlinWorkspaceService(
 
             // Update options for inlay hints
             get("inlayHints")?.asJsonObject?.apply {
-                val hints = config.hints
-                get("typeHints")?.asBoolean?.let { hints.typeHints = it }
-                get("parameterHints")?.asBoolean?.let { hints.parameterHints = it }
-                get("chainedHints")?.asBoolean?.let { hints.chainedHints = it }
+                val inlayHints = config.inlayHints
+                get("typeHints")?.asBoolean?.let { inlayHints.typeHints = it }
+                get("parameterHints")?.asBoolean?.let { inlayHints.parameterHints = it }
+                get("chainedHints")?.asBoolean?.let { inlayHints.chainedHints = it }
             }
 
             // Update diagnostics options

--- a/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
+++ b/server/src/test/kotlin/org/javacs/kt/LanguageServerTestFixture.kt
@@ -45,10 +45,10 @@ abstract class LanguageServerTestFixture(
             uri = workspaceRoot.toUri().toString()
         })
 
-        languageServer.config.hints.apply {
-            this.typeHints = true
-            this.parameterHints = true
-            this.chainedHints = true
+        languageServer.config.inlayHints.apply {
+            typeHints = true
+            parameterHints = true
+            chainedHints = true
         }
         languageServer.sourcePath.indexEnabled = false
         languageServer.connect(this)


### PR DESCRIPTION
This aligns the `Configuration` structure with the expected JSON keys again.