### PR TITLE
Model script exclusion via `SourceExclusions` and skip files entirely instead of placing them temporarily on the source path

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -157,18 +157,18 @@ class CompilerClassPath(
 
     private fun isBuildScript(file: Path): Boolean = file.fileName.toString().let { it == "pom.xml" || it == "build.gradle" || it == "build.gradle.kts" }
 
+    private fun findJavaSourceFiles(root: Path): Set<Path> {
+        val sourceMatcher = FileSystems.getDefault().getPathMatcher("glob:*.java")
+        return SourceExclusions(listOf(root), scriptsConfig)
+            .walkIncluded()
+            .filter { sourceMatcher.matches(it.fileName) }
+            .toSet()
+    }
+
     override fun close() {
         compiler.close()
         outputDirectory.delete()
     }
-}
-
-private fun findJavaSourceFiles(root: Path): Set<Path> {
-    val sourceMatcher = FileSystems.getDefault().getPathMatcher("glob:*.java")
-    return SourceExclusions(root)
-        .walkIncluded()
-        .filter { sourceMatcher.matches(it.fileName) }
-        .toSet()
 }
 
 private fun logAdded(sources: Collection<Path>, name: String) {

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -30,13 +30,6 @@ public data class DiagnosticsConfiguration(
     var debounceTime: Long = 250L
 )
 
-public data class ScriptsConfiguration(
-    /** Whether .kts scripts are handled. */
-    var enabled: Boolean = false,
-    /** Whether .gradle.kts scripts are handled. Only considered if scripts are enabled in general. */
-    var buildScriptsEnabled: Boolean = false
-)
-
 public data class JVMConfiguration(
     /** Which JVM target the Kotlin compiler uses. See Compiler.jvmTargetFrom for possible values. */
     var target: String = "default"

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -192,6 +192,8 @@ class SourceFiles(
     }
 
     fun isOpen(uri: URI): Boolean = (uri in open)
+
+    fun isIncluded(uri: URI): Boolean = exclusions.isURIIncluded(uri)
 }
 
 private fun patch(sourceText: String, change: TextDocumentContentChangeEvent): String {

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -74,8 +74,10 @@ class SourceFiles(
     private val open = mutableSetOf<URI>()
 
     fun open(uri: URI, content: String, version: Int) {
-        files[uri] = SourceVersion(content, version, languageOf(uri), isTemporary = !exclusions.isURIIncluded(uri))
-        open.add(uri)
+        if (exclusions.isURIIncluded(uri)) {
+            files[uri] = SourceVersion(content, version, languageOf(uri), isTemporary = false)
+            open.add(uri)
+        }
     }
 
     fun close(uri: URI) {

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -69,7 +69,7 @@ class SourceFiles(
     private val scriptsConfig: ScriptsConfiguration
 ) {
     private val workspaceRoots = mutableSetOf<Path>()
-    private var exclusions = SourceExclusions(workspaceRoots)
+    private var exclusions = SourceExclusions(workspaceRoots, scriptsConfig)
     private val files = NotifySourcePath(sp)
     private val open = mutableSetOf<URI>()
 
@@ -177,20 +177,16 @@ class SourceFiles(
     }
 
     private fun findSourceFiles(root: Path): Set<URI> {
-        val glob = if (scriptsConfig.enabled) "*.{kt,kts}" else "*.kt"
-        val sourceMatcher = FileSystems.getDefault().getPathMatcher("glob:$glob")
-        return SourceExclusions(root)
+        val sourceMatcher = FileSystems.getDefault().getPathMatcher("glob:*.{kt,kts}")
+        return SourceExclusions(listOf(root), scriptsConfig)
             .walkIncluded()
-            .filter {
-                sourceMatcher.matches(it.fileName)
-                && (scriptsConfig.buildScriptsEnabled || !it.endsWith(".gradle.kts"))
-            }
+            .filter { sourceMatcher.matches(it.fileName) }
             .map(Path::toUri)
             .toSet()
     }
 
     private fun updateExclusions() {
-        exclusions = SourceExclusions(workspaceRoots)
+        exclusions = SourceExclusions(workspaceRoots, scriptsConfig)
     }
 
     fun isOpen(uri: URI): Boolean = (uri in open)

--- a/server/src/test/kotlin/org/javacs/kt/ScriptTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/ScriptTest.kt
@@ -4,13 +4,17 @@ import org.hamcrest.Matchers.hasItem
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-class ScriptTest : LanguageServerTestFixture("script") {
+class ScriptTest : LanguageServerTestFixture("script", Configuration().apply {
+    scripts.enabled = true
+}) {
     @Test fun `open script`() {
         open("ExampleScript.kts")
     }
 }
 
-class EditFunctionTest : SingleFileTestFixture("script", "FunctionScript.kts") {
+class EditFunctionTest : SingleFileTestFixture("script", "FunctionScript.kts", Configuration().apply {
+    scripts.enabled = true
+}) {
     @Test fun `edit a function in a script`() {
         replace("FunctionScript.kts", 3, 18, "2", "f")
 

--- a/shared/src/main/kotlin/org/javacs/kt/ScriptsConfiguration.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/ScriptsConfiguration.kt
@@ -1,0 +1,8 @@
+package org.javacs.kt
+
+public data class ScriptsConfiguration(
+    /** Whether .kts scripts are handled. */
+    var enabled: Boolean = false,
+    /** Whether .gradle.kts scripts are handled. Only considered if scripts are enabled in general. */
+    var buildScriptsEnabled: Boolean = false
+)

--- a/shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt
@@ -9,10 +9,19 @@ import java.nio.file.Paths
 
 // TODO: Read exclusions from gitignore/settings.json/... instead of
 // hardcoding them
-class SourceExclusions(private val workspaceRoots: Collection<Path>) {
-	private val excludedPatterns = listOf(".*", "bazel-*", "bin", "build", "node_modules", "target").map { FileSystems.getDefault().getPathMatcher("glob:$it") }
-
-    constructor(workspaceRoot: Path) : this(listOf(workspaceRoot)) {}
+class SourceExclusions(
+    private val workspaceRoots: Collection<Path>,
+    private val scriptsConfig: ScriptsConfiguration
+) {
+	private val excludedPatterns = listOf(
+        ".*", "bazel-*", "bin", "build", "node_modules", "target",
+        *(when {
+            !scriptsConfig.enabled -> arrayOf("*.kts")
+            !scriptsConfig.buildScriptsEnabled -> arrayOf("*.gradle.kts")
+            else -> arrayOf()
+        }),
+    )
+        .map { FileSystems.getDefault().getPathMatcher("glob:$it") }
 
     /** Finds all non-excluded files recursively. */
     fun walkIncluded(): Sequence<Path> = workspaceRoots.asSequence().flatMap { root ->

--- a/shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt
@@ -13,14 +13,13 @@ class SourceExclusions(
     private val workspaceRoots: Collection<Path>,
     private val scriptsConfig: ScriptsConfiguration
 ) {
-	private val excludedPatterns = listOf(
-        ".*", "bazel-*", "bin", "build", "node_modules", "target",
-        *(when {
-            !scriptsConfig.enabled -> arrayOf("*.kts")
-            !scriptsConfig.buildScriptsEnabled -> arrayOf("*.gradle.kts")
-            else -> arrayOf()
-        }),
-    )
+	private val excludedPatterns = (listOf(
+        ".*", "bazel-*", "bin", "build", "node_modules", "target"
+    ) + when {
+        !scriptsConfig.enabled -> listOf("*.kts")
+        !scriptsConfig.buildScriptsEnabled -> listOf("*.gradle.kts")
+        else -> emptyList()
+    })
         .map { FileSystems.getDefault().getPathMatcher("glob:$it") }
 
     /** Finds all non-excluded files recursively. */


### PR DESCRIPTION
This PR moves the script extension checking logic introduced in #536 to `SourceExclusions`. This lets us test, in a single place, whether a URI is tracked by the source path or not. Additionally, language features (i.e. completions, hovers etc.) are now only provided for included files, previously `KotlinTextDocumentService.recover` forced these files onto the source path, largely subverting the exclusion logic and causing e.g. errors to show up in ignored files, if opened directly.