### PR TITLE
Update exclusions upon config changes and log more verbosely

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinTextDocumentService.kt
@@ -80,7 +80,10 @@ class KotlinTextDocumentService(
 
     private fun recover(uriString: String, position: Position, recompile: Recompile): Pair<CompiledFile, Int>? {
         val uri = parseURI(uriString)
-        if (!sf.isIncluded(uri)) return null
+        if (!sf.isIncluded(uri)) {
+            LOG.warn("URI is excluded, therefore cannot be recovered: $uri")
+            return null
+        }
         val content = sp.content(uri)
         val offset = offset(content, position.line, position.character)
         val shouldRecompile = when (recompile) {

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -140,6 +140,7 @@ class KotlinWorkspaceService(
                 val scripts = config.scripts
                 get("enabled")?.asBoolean?.let { scripts.enabled = it }
                 get("buildScriptsEnabled")?.asBoolean?.let { scripts.buildScriptsEnabled = it }
+                sf.updateExclusions()
             }
 
             // Update code-completion options

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -190,6 +190,7 @@ class SourceFiles(
 
     fun updateExclusions() {
         exclusions = SourceExclusions(workspaceRoots, scriptsConfig)
+        LOG.info("Updated exclusions: ${exclusions.excludedPatterns}")
     }
 
     fun isOpen(uri: URI): Boolean = (uri in open)

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -74,7 +74,7 @@ class SourceFiles(
     private val open = mutableSetOf<URI>()
 
     fun open(uri: URI, content: String, version: Int) {
-        if (exclusions.isURIIncluded(uri)) {
+        if (isIncluded(uri)) {
             files[uri] = SourceVersion(content, version, languageOf(uri), isTemporary = false)
             open.add(uri)
         }
@@ -98,7 +98,7 @@ class SourceFiles(
     }
 
     fun edit(uri: URI, newVersion: Int, contentChanges: List<TextDocumentContentChangeEvent>) {
-        if (exclusions.isURIIncluded(uri)) {
+        if (isIncluded(uri)) {
             val existing = files[uri]!!
             var newText = existing.content
 
@@ -143,7 +143,7 @@ class SourceFiles(
         null
     }
 
-    private fun isSource(uri: URI): Boolean = exclusions.isURIIncluded(uri) && languageOf(uri) != null
+    private fun isSource(uri: URI): Boolean = isIncluded(uri) && languageOf(uri) != null
 
     private fun languageOf(uri: URI): Language? {
         val fileName = uri.filePath?.fileName?.toString() ?: return null

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -154,6 +154,7 @@ class SourceFiles(
     }
 
     fun addWorkspaceRoot(root: Path) {
+        LOG.info("Searching $root using exclusions: ${exclusions.excludedPatterns}")
         val addSources = findSourceFiles(root)
 
         logAdded(addSources, root)

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -188,7 +188,7 @@ class SourceFiles(
             .toSet()
     }
 
-    private fun updateExclusions() {
+    fun updateExclusions() {
         exclusions = SourceExclusions(workspaceRoots, scriptsConfig)
     }
 


### PR DESCRIPTION
A small follow-up PR to #543. With this, `SourceExclusions` should now be synchronized properly when a `didChangeConfiguration` notification is received. Additionally, the exclusion patterns are now logged, to make it more apparent which files are included or excluded.