### PR TITLE
Fix negative active signature/parameter

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt
+++ b/server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt
@@ -23,7 +23,7 @@ import org.javacs.kt.LOG
 
 fun fetchSignatureHelpAt(file: CompiledFile, cursor: Int): SignatureHelp? {
     val (signatures, activeDeclaration, activeParameter) = getSignatureTriplet(file, cursor) ?: return nullResult("No call around ${file.describePosition(cursor)}")
-    return SignatureHelp(signatures, activeDeclaration, activeParameter)
+    return SignatureHelp(signatures, (if (activeDeclaration >= 0) activeDeclaration else null), (if (activeDeclaration >= 0) activeParameter else null))
 }
 
 /**

--- a/server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt
+++ b/server/src/main/kotlin/org/javacs/kt/signaturehelp/SignatureHelp.kt
@@ -20,11 +20,10 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.javacs.kt.LOG
-import kotlin.math.abs
 
 fun fetchSignatureHelpAt(file: CompiledFile, cursor: Int): SignatureHelp? {
     val (signatures, activeSignature, activeParameter) = getSignatureTriplet(file, cursor) ?: return nullResult("No call around ${file.describePosition(cursor)}")
-    return SignatureHelp(signatures, activeSignature,activeParameter)
+    return SignatureHelp(signatures, activeSignature, activeParameter)
 }
 
 /**
@@ -42,6 +41,7 @@ fun getDocString(file: CompiledFile, cursor: Int): String {
 }
 
 // TODO better function name?
+@Suppress("ReturnCount")
 private fun getSignatureTriplet(file: CompiledFile, cursor: Int): Triple<List<SignatureInformation>, Int?, Int?>? {
     val call = file.parseAtPoint(cursor)?.findParent<KtCallExpression>() ?: return null
     val candidates = candidates(call, file)
@@ -127,6 +127,7 @@ private fun isCompatibleWith(call: KtCallExpression, candidate: CallableDescript
     return true
 }
 
+@Suppress("ReturnCount")
 private fun activeParameter(call: KtCallExpression, cursor: Int): Int? {
     val args = call.valueArgumentList ?: return null
     val text = args.text


### PR DESCRIPTION
I'm using the [Helix Editor](https://helix-editor.com) and when I put my cursor inside a string, and request the help signature it throws an error that `-1` is an invalid value for u32. (helix is written in Rust)

I took a look at the Language Server Protocol Spec and [saw that the `activeSignature` and `activeParameter` are unsigned Integers](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#signatureHelp) according to the spec, so the implementation in helix seems to be correct.

This means these functions should never return a value below 0.

My change sets the activeParameter/activeSignature to `null` if the value is not greater-equals 0, which omits the activeSignature/activeParameter value in the response, as the spec allows, which helix happily accepts. (Helix sets them to the default value of `0` if the values are null or omitted [see here] and [here])

(I've never written any Kotlin code, so feel free to recommend other ways to implement this)

# Alternatives

With my change it is up to the client to choose the signature and parameter, and as the spec mentions, `[...] In future version of the protocol, this property might become mandatory to better express this.`, this change may not be valid in future versions. The alternative would be to return 0 for both functions, if they don't return a value greater-equals than 0.

[see here]: https://github.com/helix-editor/helix/blob/eca3ccff76b9f45dd2b266215764fe7630dee884/helix-term/src/commands/lsp.rs#L1208

[here]: https://github.com/helix-editor/helix/blob/eca3ccff76b9f45dd2b266215764fe7630dee884/helix-term/src/commands/lsp.rs#L1234

