### PR TITLE
Remove semantic tokens for string literals (templates)

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt
+++ b/server/src/main/kotlin/org/javacs/kt/semantictokens/SemanticTokens.kt
@@ -187,9 +187,8 @@ private fun elementToken(element: PsiElement, bindingContext: BindingContext): S
 
         // Literals and string interpolations
 
-        is KtSimpleNameStringTemplateEntry, is KtBlockStringTemplateEntry ->
+        is KtSimpleNameStringTemplateEntry ->
             SemanticToken(elementRange, SemanticTokenType.INTERPOLATION_ENTRY)
-        is KtStringTemplateExpression -> SemanticToken(elementRange, SemanticTokenType.STRING)
         is PsiLiteralExpression -> {
             val tokenType = when (element.type) {
                 PsiType.INT, PsiType.LONG, PsiType.DOUBLE -> SemanticTokenType.NUMBER

--- a/server/src/test/kotlin/org/javacs/kt/SemanticTokensTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/SemanticTokensTest.kt
@@ -22,7 +22,6 @@ class SemanticTokensTest : SingleFileTestFixture("semantictokens", "SemanticToke
         val expectedConst = sequenceOf(
             SemanticToken(range(constLine, 5, constLine, 13), SemanticTokenType.PROPERTY, setOf(SemanticTokenModifier.DECLARATION, SemanticTokenModifier.READONLY)), // constant
             SemanticToken(range(constLine, 15, constLine, 21), SemanticTokenType.CLASS), // String
-            SemanticToken(range(constLine, 24, constLine, 40), SemanticTokenType.STRING), // "test $variable"
             SemanticToken(range(constLine, 30, constLine, 39), SemanticTokenType.INTERPOLATION_ENTRY), // $variable
             SemanticToken(range(constLine, 31, constLine, 39), SemanticTokenType.PROPERTY), // variable
         )

--- a/server/src/test/resources/semantictokens/SemanticTokens.kt
+++ b/server/src/test/resources/semantictokens/SemanticTokens.kt
@@ -1,5 +1,5 @@
 var variable = 3
-val constant: String = "test $variable"
+val constant: String = "test $variable ${12}"
 val string = "abc"
 
 data class Type(val property: Int)

--- a/server/src/test/resources/semantictokens/SemanticTokens.kt
+++ b/server/src/test/resources/semantictokens/SemanticTokens.kt
@@ -1,5 +1,6 @@
 var variable = 3
 val constant: String = "test $variable"
+val string = "abc"
 
 data class Type(val property: Int)
 


### PR DESCRIPTION
Currently, the language server emits a single token for every string literal, which in clients like VSCode covers up interpolations:

<img width="340" alt="Screenshot 2024-01-16 at 01 18 52" src="https://github.com/fwcd/kotlin-language-server/assets/30873659/7c09bcf7-7bfa-42c7-9973-c6da470f80ba">

Ideally we should probably slice up the string literals to exclude child ranges (that's what SourceKit-LSP seems to do), but for now we are better off not including string literals, thereby deferring the highlighting to e.g. the TextMate grammar:

<img width="335" alt="Screenshot 2024-01-16 at 01 19 08" src="https://github.com/fwcd/kotlin-language-server/assets/30873659/8199fb69-f020-42c7-9df4-edd7a8b0f4f0">
