### PR TITLE
Update LSP4J to 0.21.2

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -8,7 +8,7 @@ javaPlatform {
 
 val kotlinVersion = "1.9.20"
 val exposedVersion = "0.37.3"
-val lsp4jVersion = "0.15.0"
+val lsp4jVersion = "0.21.2"
 
 // constrain the dependencies that we use to these specific versions
 dependencies {


### PR DESCRIPTION
Fixes #550. Java 21 should already be supported and the log message should be fixed in the newer LSP4J version.