### PR TITLE
Fix compatibility issues + bugs

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -39,15 +39,6 @@ public data class CompilerConfiguration(
     val jvm: JVMConfiguration = JVMConfiguration()
 )
 
-public data class SymbolResolveSupport(
-    val enabled: Boolean = false,
-    val properties: List<String> = emptyList()
-)
-
-public data class WorkspaceConfiguration(
-    var symbolResolveSupport: SymbolResolveSupport = SymbolResolveSupport()
-)
-
 public data class IndexingConfiguration(
     /** Whether an index of global symbols should be built in the background. */
     var enabled: Boolean = true
@@ -116,6 +107,5 @@ public data class Configuration(
     val indexing: IndexingConfiguration = IndexingConfiguration(),
     val externalSources: ExternalSourcesConfiguration = ExternalSourcesConfiguration(),
     val inlayHints: InlayHintsConfiguration = InlayHintsConfiguration(),
-    val formatting: FormattingConfiguration = FormattingConfiguration(),
-    val workspace: WorkspaceConfiguration = WorkspaceConfiguration()
+    val formatting: FormattingConfiguration = FormattingConfiguration()
 )

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -39,6 +39,15 @@ public data class CompilerConfiguration(
     val jvm: JVMConfiguration = JVMConfiguration()
 )
 
+public data class SymbolResolveSupport(
+    val enabled: Boolean = false,
+    val properties: List<String> = emptyList()
+)
+
+public data class WorkspaceConfiguration(
+    var symbolResolveSupport: SymbolResolveSupport = SymbolResolveSupport()
+)
+
 public data class IndexingConfiguration(
     /** Whether an index of global symbols should be built in the background. */
     var enabled: Boolean = true
@@ -108,4 +117,5 @@ public data class Configuration(
     val externalSources: ExternalSourcesConfiguration = ExternalSourcesConfiguration(),
     val inlayHints: InlayHintsConfiguration = InlayHintsConfiguration(),
     val formatting: FormattingConfiguration = FormattingConfiguration(),
+    val workspace: WorkspaceConfiguration = WorkspaceConfiguration()
 )

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -108,7 +108,7 @@ class KotlinLanguageServer(
             serverCapabilities.renameProvider = Either.forRight(RenameOptions(false))
         }
 
-        config.workspace.symbolResolveSupport = clientHasWorkspaceSymbolResolveSupport(clientCapabilities)
+        workspaces.initialize(clientCapabilities)
 
         @Suppress("DEPRECATION")
         val folders = params.workspaceFolders?.takeIf { it.isNotEmpty() }
@@ -142,11 +142,6 @@ class KotlinLanguageServer(
 
         InitializeResult(serverCapabilities, serverInfo)
     }
-
-    private fun clientHasWorkspaceSymbolResolveSupport(clientCapabilities: ClientCapabilities) =
-        clientCapabilities?.workspace?.symbol?.resolveSupport?.properties?.let { properties ->
-            if (properties.size > 0) SymbolResolveSupport(true, properties) else null
-        } ?: SymbolResolveSupport(false, emptyList())
 
     private fun connectLoggingBackend() {
         val backend: (LogMessage) -> Unit = {

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -108,6 +108,10 @@ class KotlinLanguageServer(
             serverCapabilities.renameProvider = Either.forRight(RenameOptions(false))
         }
 
+        config.workspace.symbolResolveSupport = clientCapabilities?.workspace?.symbol?.resolveSupport?.properties?.let { properties ->
+            if (properties.size > 0) SymbolResolveSupport(true, properties) else null
+        } ?: SymbolResolveSupport(false, emptyList())
+
         @Suppress("DEPRECATION")
         val folders = params.workspaceFolders?.takeIf { it.isNotEmpty() }
             ?: params.rootUri?.let(::WorkspaceFolder)?.let(::listOf)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -108,9 +108,7 @@ class KotlinLanguageServer(
             serverCapabilities.renameProvider = Either.forRight(RenameOptions(false))
         }
 
-        config.workspace.symbolResolveSupport = clientCapabilities?.workspace?.symbol?.resolveSupport?.properties?.let { properties ->
-            if (properties.size > 0) SymbolResolveSupport(true, properties) else null
-        } ?: SymbolResolveSupport(false, emptyList())
+        config.workspace.symbolResolveSupport = clientHasWorkspaceSymbolResolveSupport(clientCapabilities)
 
         @Suppress("DEPRECATION")
         val folders = params.workspaceFolders?.takeIf { it.isNotEmpty() }
@@ -144,6 +142,11 @@ class KotlinLanguageServer(
 
         InitializeResult(serverCapabilities, serverInfo)
     }
+
+    private fun clientHasWorkspaceSymbolResolveSupport(clientCapabilities: ClientCapabilities) =
+        clientCapabilities?.workspace?.symbol?.resolveSupport?.properties?.let { properties ->
+            if (properties.size > 0) SymbolResolveSupport(true, properties) else null
+        } ?: SymbolResolveSupport(false, emptyList())
 
     private fun connectLoggingBackend() {
         val backend: (LogMessage) -> Unit = {

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -189,7 +189,7 @@ class KotlinWorkspaceService(
 
     @Suppress("DEPRECATION")
     override fun symbol(params: WorkspaceSymbolParams): CompletableFuture<Either<List<SymbolInformation>, List<WorkspaceSymbol>>> {
-        val result = workspaceSymbols(params.query, sp)
+        val result = workspaceSymbols(!config.workspace.symbolResolveSupport.enabled, params.query, sp)
 
         return CompletableFuture.completedFuture(Either.forRight(result))
     }

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.CompletableFuture
 import com.google.gson.JsonElement
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import org.javacs.kt.symbols.symbolResolveSupport
 
 class KotlinWorkspaceService(
     private val sf: SourceFiles,
@@ -26,9 +27,14 @@ class KotlinWorkspaceService(
 ) : WorkspaceService, LanguageClientAware {
     private val gson = Gson()
     private var languageClient: LanguageClient? = null
+    private var clientCapabilities: ClientCapabilities? = null
 
     override fun connect(client: LanguageClient): Unit {
         languageClient = client
+    }
+
+    fun initialize(clientCapabilities: ClientCapabilities) {
+        this.clientCapabilities = clientCapabilities
     }
 
     override fun executeCommand(params: ExecuteCommandParams): CompletableFuture<Any> {
@@ -189,7 +195,7 @@ class KotlinWorkspaceService(
 
     @Suppress("DEPRECATION")
     override fun symbol(params: WorkspaceSymbolParams): CompletableFuture<Either<List<SymbolInformation>, List<WorkspaceSymbol>>> {
-        val result = workspaceSymbols(!config.workspace.symbolResolveSupport.enabled, params.query, sp)
+        val result = workspaceSymbols(params.query, sp, !clientCapabilities.symbolResolveSupport.enabled)
 
         return CompletableFuture.completedFuture(Either.forRight(result))
     }

--- a/server/src/main/kotlin/org/javacs/kt/symbols/SymbolResolveSupport.kt
+++ b/server/src/main/kotlin/org/javacs/kt/symbols/SymbolResolveSupport.kt
@@ -1,0 +1,13 @@
+package org.javacs.kt.symbols
+
+import org.eclipse.lsp4j.ClientCapabilities
+
+data class SymbolResolveSupport(
+    val enabled: Boolean = false,
+    val properties: List<String> = emptyList()
+)
+
+val ClientCapabilities?.symbolResolveSupport
+    get() = this?.workspace?.symbol?.resolveSupport?.properties?.let { properties ->
+        if (properties.size > 0) SymbolResolveSupport(true, properties) else null
+    } ?: SymbolResolveSupport(false, emptyList())

--- a/shared/src/main/kotlin/org/javacs/kt/Logger.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/Logger.kt
@@ -3,7 +3,6 @@ package org.javacs.kt
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.*
-import java.util.logging.Formatter
 import java.util.logging.LogRecord
 import java.util.logging.Handler
 import java.util.logging.Level
@@ -136,7 +135,7 @@ class Logger {
 
     fun connectStdioBackend() {
         connectOutputBackend { println(it.formatted) }
-        connectOutputBackend { System.err.println(it.formatted) }
+        connectErrorBackend { System.err.println(it.formatted) }
     }
 
     private fun insertPlaceholders(msg: String, placeholders: Array<out Any?>): String {


### PR DESCRIPTION
1) From LSP spec [3.16 to 3.17](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_symbol), dropping the location attribute from the
   response to `workspace/symbol` is only permitted if the client
   capability `workspace.symbol.resolveSupport` is advertized. Without
   this setting, the `location` attribute should be present.
2) `findDeclarationCursorSite` constructs a location using a non-uri
   path in the uri property. This leads to document symbol rename
   for example to not work.
3) THe stdio backend for logging accidentally overrides the stdout
   backend with the one meant for stderr.

