### PR TITLE
Add test of checking file URI prefix for renaming

### DIFF
--- a/server/src/test/kotlin/org/javacs/kt/RenameTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/RenameTest.kt
@@ -1,6 +1,7 @@
 package org.javacs.kt
 
 import org.eclipse.lsp4j.Position
+import org.hamcrest.Matchers.startsWith
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.equalTo
 import org.junit.Assert.assertThat
@@ -14,6 +15,7 @@ class RenameReferenceTest : SingleFileTestFixture("rename", "SomeClass.kt") {
         val changes = edits.documentChanges
 
         assertThat(changes.size, equalTo(3))
+        assertThat(changes[0].left.textDocument.uri, startsWith("file://"))
         assertThat(changes[0].left.textDocument.uri, containsString("SomeOtherClass.kt"))
 
         assertThat(changes[0].left.edits[0].newText, equalTo("NewClassName"))
@@ -32,6 +34,7 @@ class RenameDefinitionTest : SingleFileTestFixture("rename", "SomeOtherClass.kt"
         println(changes)
 
         assertThat(changes.size, equalTo(3))
+        assertThat(changes[0].left.textDocument.uri, startsWith("file://"))
         assertThat(changes[0].left.textDocument.uri, containsString("SomeOtherClass.kt"))
 
         assertThat(changes[0].left.edits[0].newText, equalTo("NewClassName"))
@@ -51,11 +54,13 @@ class RenameDeclarationSiteTest : SingleFileTestFixture("rename", "DeclSite.kt")
         assertThat(changes.size, equalTo(2))
 
         val firstChange = changes[0].left
+        assertThat(firstChange.textDocument.uri, startsWith("file://"))
         assertThat(firstChange.textDocument.uri, containsString("DeclSite.kt"))
         assertThat(firstChange.edits[0].newText, equalTo("newvarname"))
         assertThat(firstChange.edits[0].range, equalTo(range(3, 5, 3, 10)))
 
         val secondChange = changes[1].left
+        assertThat(secondChange.textDocument.uri, startsWith("file://"))
         assertThat(secondChange.textDocument.uri, containsString("UsageSite.kt"))
         assertThat(secondChange.edits[0].newText, equalTo("newvarname"))
         assertThat(secondChange.edits[0].range, equalTo(range(4, 13, 4, 18)))
@@ -69,11 +74,13 @@ class RenameDeclarationSiteTest : SingleFileTestFixture("rename", "DeclSite.kt")
         assertThat(changes.size, equalTo(2))
 
         val firstChange = changes[0].left
+        assertThat(firstChange.textDocument.uri, startsWith("file://"))
         assertThat(firstChange.textDocument.uri, containsString("DeclSite.kt"))
         assertThat(firstChange.edits[0].newText, equalTo("newvarname"))
         assertThat(firstChange.edits[0].range, equalTo(range(3, 5, 3, 10)))
 
         val secondChange = changes[1].left
+        assertThat(secondChange.textDocument.uri, startsWith("file://"))
         assertThat(secondChange.textDocument.uri, containsString("UsageSite.kt"))
         assertThat(secondChange.edits[0].newText, equalTo("newvarname"))
         assertThat(secondChange.edits[0].range, equalTo(range(4, 13, 4, 18)))


### PR DESCRIPTION
Related to this PR #563.

I thought it would be nice if we have an assertion to check if `textDocument.url` correctly holds `file://` prefix.