### PR TITLE
Allow user specified exclusion patterns

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -159,7 +159,7 @@ class CompilerClassPath(
 
     private fun findJavaSourceFiles(root: Path): Set<Path> {
         val sourceMatcher = FileSystems.getDefault().getPathMatcher("glob:*.java")
-        return SourceExclusions(listOf(root), scriptsConfig)
+        return SourceExclusions(listOf(root), scriptsConfig, mutableListOf())
             .walkIncluded()
             .filter { sourceMatcher.matches(it.fileName) }
             .toSet()

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -70,12 +70,12 @@ data class FormattingConfiguration(
     var ktfmt: KtfmtConfiguration = KtfmtConfiguration()
 )
 
-fun getStoragePath(params: InitializeParams): Path? {
+fun getInitializationOptions(params: InitializeParams): InitializationOptions? {
     params.initializationOptions?.let { initializationOptions ->
         val gson = GsonBuilder().registerTypeHierarchyAdapter(Path::class.java, GsonPathConverter()).create()
         val options = gson.fromJson(initializationOptions as JsonElement, InitializationOptions::class.java)
 
-        return options?.storagePath
+        return options
     }
 
     return null
@@ -83,7 +83,9 @@ fun getStoragePath(params: InitializeParams): Path? {
 
 data class InitializationOptions(
     // A path to a directory used by the language server to store data. Used for caching purposes.
-    val storagePath: Path?
+    val storagePath: Path?,
+    // Additional paths to exclude from source files.
+    val additionalSourceExclusions: List<String>?
 )
 
 class GsonPathConverter : JsonDeserializer<Path?> {

--- a/shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt
@@ -11,13 +11,14 @@ import java.nio.file.Paths
 // hardcoding them
 class SourceExclusions(
     private val workspaceRoots: Collection<Path>,
-    private val scriptsConfig: ScriptsConfiguration
+    private val scriptsConfig: ScriptsConfiguration,
+    private val additionalSourceExclusions: List<String>
 ) {
     val excludedPatterns = (listOf(
         ".git", ".hg", ".svn",                                                      // Version control systems
         ".idea", ".idea_modules", ".vs", ".vscode", ".code-workspace", ".settings", // IDEs
         "bazel-*", "bin", "build", "node_modules", "target",                        // Build systems
-    ) + when {
+    ) + additionalSourceExclusions + when {
         !scriptsConfig.enabled -> listOf("*.kts")
         !scriptsConfig.buildScriptsEnabled -> listOf("*.gradle.kts")
         else -> emptyList()


### PR DESCRIPTION
Reads initialization options for additional patterns to exclude from source files.

https://github.com/fwcd/kotlin-language-server/pull/560 demonstrated that users need to be able to specify patterns to exclude and that hardcoding it forever probably wasn't sustainable. So this makes it configureable.

It seems to me the initialization options is the most natural place to do this (rather than the settings configuration, for example). Similar to adding workspace roots, the user provided exclusions are provided to `SourceFiles` at initialization time.

This probably merits updating the documentation, but since I'd also like to improve the neovim documentation anyway I'll probably do that in another PR (mainly, there's no documentation that you need to have a "kotlin" object under settings, since the configuration parser is tailored to the configuration response that VSCode gives).

For example, in my neovim init.lua I'd write
```
vim.lsp.start({
	name = "kotlin-language-server",
	cmd = {
		...
	},
	filetypes = ....
	root_dir = ...
	init_options = {
		storagePath = ....,
		additionalSourceExclusions = { "new", "source", "exclusions*" },
	},
	settings = {
		kotlin = {
			scripts = {
				...
			},
			completion = {
				...
			},
		},
	},
})
```