### PR TITLE
Make maven repository optional again

### DIFF
--- a/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/Home.kt
@@ -17,10 +17,7 @@ private val possibleMavenRepositoryPaths =
     )
     .filterNotNull()
 
-internal val mavenRepository =
+internal val mavenRepository: Path? =
     possibleMavenRepositoryPaths.firstOrNull { Files.exists(it) }
-        ?: throw KotlinLSException(
-            "No repositories found at \$MAVEN_REPOSITORY, \$MAVEN_HOME, \$M2_HOME or \$HOME/.m2"
-        )
 
 internal val gradleHome = createPathOrNull("GRADLE_USER_HOME") ?: userHome.resolve(".gradle")

--- a/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/classpath/MavenClassPathResolver.kt
@@ -88,10 +88,10 @@ private fun readMavenDependencyListWithSources(artifacts: Set<Artifact>, sources
 
 private fun findMavenArtifact(a: Artifact, source: Boolean): Path? {
     val result = mavenRepository
-        .resolve(a.group.replace('.', File.separatorChar))
-        .resolve(a.artifact)
-        .resolve(a.version)
-        .resolve(mavenJarName(a, source))
+        ?.resolve(a.group.replace('.', File.separatorChar))
+        ?.resolve(a.artifact)
+        ?.resolve(a.version)
+        ?.resolve(mavenJarName(a, source))
 
     return if (Files.exists(result))
         result


### PR DESCRIPTION
### Fixes #564 

This fixes a small regression introduced in #518 that caused the language server to crash if no Maven repository was found.