### PR TITLE
Make code generation (for Java interoperability) opt-in

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -18,6 +18,7 @@ import java.nio.file.Path
 class CompilerClassPath(
     private val config: CompilerConfiguration,
     private val scriptsConfig: ScriptsConfiguration,
+    private val codegenConfig: CodegenConfiguration,
     private val databaseService: DatabaseService
 ) : Closeable {
     val workspaceRoots = mutableSetOf<Path>()
@@ -33,6 +34,7 @@ class CompilerClassPath(
         classPath.map { it.compiledJar }.toSet(),
         buildScriptClassPath,
         scriptsConfig,
+        codegenConfig,
         outputDirectory
     )
         private set
@@ -87,6 +89,7 @@ class CompilerClassPath(
                 classPath.map { it.compiledJar }.toSet(),
                 buildScriptClassPath,
                 scriptsConfig,
+                codegenConfig,
                 outputDirectory
             )
             updateCompilerConfiguration()

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -17,6 +17,11 @@ public data class SnippetsConfiguration(
     var enabled: Boolean = true
 )
 
+public data class CodegenConfiguration(
+    /** Whether to enable code generation to a temporary build directory for Java interoperability. */
+    var enabled: Boolean = true
+)
+
 public data class CompletionConfiguration(
     val snippets: SnippetsConfiguration = SnippetsConfiguration()
 )
@@ -100,6 +105,7 @@ class GsonPathConverter : JsonDeserializer<Path?> {
 }
 
 public data class Configuration(
+    val codegen: CodegenConfiguration = CodegenConfiguration(),
     val compiler: CompilerConfiguration = CompilerConfiguration(),
     val completion: CompletionConfiguration = CompletionConfiguration(),
     val diagnostics: DiagnosticsConfiguration = DiagnosticsConfiguration(),

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -19,7 +19,7 @@ public data class SnippetsConfiguration(
 
 public data class CodegenConfiguration(
     /** Whether to enable code generation to a temporary build directory for Java interoperability. */
-    var enabled: Boolean = true
+    var enabled: Boolean = false
 )
 
 public data class CompletionConfiguration(

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -26,7 +26,7 @@ class KotlinLanguageServer(
     val config: Configuration = Configuration()
 ) : LanguageServer, LanguageClientAware, Closeable {
     val databaseService = DatabaseService()
-    val classPath = CompilerClassPath(config.compiler, config.scripts, databaseService)
+    val classPath = CompilerClassPath(config.compiler, config.scripts, config.codegen, databaseService)
 
     private val tempDirectory = TemporaryDirectory()
     private val uriContentProvider = URIContentProvider(ClassContentProvider(config.externalSources, classPath, tempDirectory, CompositeSourceArchiveProvider(JdkSourceArchiveProvider(classPath), ClassPathSourceArchiveProvider(classPath))))

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -159,6 +159,12 @@ class KotlinWorkspaceService(
                 sf.updateExclusions()
             }
 
+            // Update code generation options
+            get("codegen")?.asJsonObject?.apply {
+                val codegen = config.codegen
+                get("enabled")?.asBoolean?.let { codegen.enabled = it }
+            }
+
             // Update code-completion options
             get("completion")?.asJsonObject?.apply {
                 val completion = config.completion

--- a/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
+++ b/server/src/main/kotlin/org/javacs/kt/compiler/Compiler.kt
@@ -57,6 +57,7 @@ import kotlin.script.experimental.host.configurationDependencies
 import kotlin.script.experimental.jvm.defaultJvmScriptingHostConfiguration
 import kotlin.script.experimental.jvm.JvmDependency
 import org.javacs.kt.LOG
+import org.javacs.kt.CodegenConfiguration
 import org.javacs.kt.CompilerConfiguration
 import org.javacs.kt.ScriptsConfiguration
 import org.javacs.kt.util.KotlinLSException
@@ -460,6 +461,7 @@ class Compiler(
     classPath: Set<Path>,
     buildScriptClassPath: Set<Path> = emptySet(),
     scriptsConfig: ScriptsConfiguration,
+    private val codegenConfig: CodegenConfiguration,
     private val outputDirectory: File,
 ) : Closeable {
     private var closed = false
@@ -584,7 +586,7 @@ class Compiler(
     }
 
     fun generateCode(module: ModuleDescriptor, bindingContext: BindingContext, files: Collection<KtFile>) {
-        outputDirectory.let {
+        outputDirectory.takeIf { codegenConfig.enabled }?.let {
             compileLock.withLock {
                 val compileEnv = compileEnvironmentFor(CompilationKind.DEFAULT)
                 val state = GenerationState.Builder(

--- a/server/src/test/kotlin/org/javacs/kt/CompiledFileTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/CompiledFileTest.kt
@@ -30,12 +30,13 @@ class CompiledFileTest {
         javaSourcePath = setOf(),
         classPath = setOf(),
         scriptsConfig = ScriptsConfiguration(),
+        codegenConfig = CodegenConfiguration(),
         outputDirectory = outputDirectory
     ).use { compiler ->
         val file = testResourcesRoot().resolve("compiledFile/CompiledFileExample.kt")
         val content = Files.readAllLines(file).joinToString("\n")
         val parse = compiler.createKtFile(content, file)
-        val classPath = CompilerClassPath(CompilerConfiguration(), ScriptsConfiguration(), DatabaseService())
+        val classPath = CompilerClassPath(CompilerConfiguration(), ScriptsConfiguration(), CodegenConfiguration(), DatabaseService())
         val sourcePath = listOf(parse)
         val (context, container) = compiler.compileKtFiles(sourcePath, sourcePath)
         CompiledFile(content, parse, context, container, sourcePath, classPath)

--- a/server/src/test/kotlin/org/javacs/kt/CompilerTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/CompilerTest.kt
@@ -33,6 +33,7 @@ private class FileToEdit {
                 javaSourcePath = setOf(),
                 classPath = setOf(),
                 scriptsConfig = ScriptsConfiguration(),
+                codegenConfig = CodegenConfiguration(),
                 outputDirectory = outputDirectory
             )
         }


### PR DESCRIPTION
Code generation as implemented in #334 is currently rather experimental and throws [a lot of exceptions](https://github.com/fwcd/kotlin-language-server/issues/500) on recent Kotlin versions. Until this is addressed, it would be a better user experience if we just disable code generation by default and let advanced users opt-in by setting

```json
{
  "kotlin.codegen.enabled": true
}
```

The downside is that Java interoperability will no longer work without this option, but given that it doesn't really seem to work properly in the current state, I believe making it opt-in and experimental for now would be an improvement over the status quo.

cc @daplf 