### PR TITLE
Return null context if expression fails to compile

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompiledFile.kt
@@ -45,10 +45,10 @@ class CompiledFile(
     }
 
     fun typeOfExpression(expression: KtExpression, scopeWithImports: LexicalScope): KotlinType? =
-            bindingContextOf(expression, scopeWithImports).getType(expression)
+            bindingContextOf(expression, scopeWithImports)?.getType(expression)
 
-    fun bindingContextOf(expression: KtExpression, scopeWithImports: LexicalScope): BindingContext =
-            classPath.compiler.compileKtExpression(expression, scopeWithImports, sourcePath, kind).first
+    fun bindingContextOf(expression: KtExpression, scopeWithImports: LexicalScope): BindingContext? =
+            classPath.compiler.compileKtExpression(expression, scopeWithImports, sourcePath, kind)?.first
 
     private fun expandForType(cursor: Int, surroundingExpr: KtExpression): KtExpression {
         val dotParent = surroundingExpr.parent as? KtDotQualifiedExpression
@@ -73,7 +73,7 @@ class CompiledFile(
         val scope = scopeAtPoint(cursor) ?: return nullResult("Couldn't find scope at ${describePosition(cursor)}")
         // NOTE: Due to our tiny-fake-file mechanism, we may have `path == /dummy.virtual.kt != parse.containingFile.toPath`
         val path = surroundingExpr.containingFile.toPath()
-        val context = bindingContextOf(surroundingExpr, scope)
+        val context = bindingContextOf(surroundingExpr, scope) ?: return null
         LOG.info("Hovering {}", surroundingExpr)
         return referenceFromContext(cursor, path, context)
     }

--- a/server/src/main/kotlin/org/javacs/kt/hover/Hovers.kt
+++ b/server/src/main/kotlin/org/javacs/kt/hover/Hovers.kt
@@ -38,7 +38,8 @@ private fun typeHoverAt(file: CompiledFile, cursor: Int): Hover? {
     val expression = file.parseAtPoint(cursor)?.findParent<KtExpression>() ?: return null
     val javaDoc: String = expression.children.mapNotNull { (it as? PsiDocCommentBase)?.text }.map(::renderJavaDoc).firstOrNull() ?: ""
     val scope = file.scopeAtPoint(cursor) ?: return null
-    val hoverText = renderTypeOf(expression, file.bindingContextOf(expression, scope))
+    val context = file.bindingContextOf(expression, scope) ?: return null
+    val hoverText = renderTypeOf(expression, context)
     val hover = MarkupContent("markdown", listOf("```kotlin\n$hoverText\n```", javaDoc).filter { it.isNotEmpty() }.joinToString("\n---\n"))
     return Hover(hover)
 }

--- a/server/src/test/kotlin/org/javacs/kt/CompilerTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/CompilerTest.kt
@@ -89,7 +89,7 @@ private class FileToEdit {
         val function = original.findElementAt(49)!!.parentsWithSelf.filterIsInstance<KtNamedFunction>().first()
         val scope = context.get(BindingContext.LEXICAL_SCOPE, function.bodyExpression)!!
         val recompile = compiler.createKtDeclaration("""private fun singleExpressionFunction() = intFunction()""")
-        val (recompileContext, _) = compiler.compileKtExpression(recompile, scope, setOf(original))
+        val (recompileContext, _) = compiler.compileKtExpression(recompile, scope, setOf(original))!!
         val intFunctionRef = recompile.findElementAt(41)!!.parentsWithSelf.filterIsInstance<KtReferenceExpression>().first()
         val target = recompileContext.get(BindingContext.REFERENCE_TARGET, intFunctionRef)!!
 


### PR DESCRIPTION
This prevents compilation failures from propagating as exceptions.

Picked from https://github.com/kotlin-community-tools/kotlin-language-server/commit/eadceb7c512d5b2903b51595713132a0b735d515