### PR TITLE
Read excluded patterns from configuration

### DIFF
--- a/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
+++ b/server/src/main/kotlin/org/javacs/kt/CompilerClassPath.kt
@@ -18,6 +18,7 @@ import java.nio.file.Path
 class CompilerClassPath(
     private val config: CompilerConfiguration,
     private val scriptsConfig: ScriptsConfiguration,
+    private val exclusionsConfig: ExclusionsConfiguration,
     private val codegenConfig: CodegenConfiguration,
     private val databaseService: DatabaseService
 ) : Closeable {
@@ -162,7 +163,7 @@ class CompilerClassPath(
 
     private fun findJavaSourceFiles(root: Path): Set<Path> {
         val sourceMatcher = FileSystems.getDefault().getPathMatcher("glob:*.java")
-        return SourceExclusions(listOf(root), scriptsConfig)
+        return SourceExclusions(listOf(root), scriptsConfig, exclusionsConfig)
             .walkIncluded()
             .filter { sourceMatcher.matches(it.fileName) }
             .toSet()

--- a/server/src/main/kotlin/org/javacs/kt/Configuration.kt
+++ b/server/src/main/kotlin/org/javacs/kt/Configuration.kt
@@ -114,4 +114,5 @@ public data class Configuration(
     val externalSources: ExternalSourcesConfiguration = ExternalSourcesConfiguration(),
     val inlayHints: InlayHintsConfiguration = InlayHintsConfiguration(),
     val formatting: FormattingConfiguration = FormattingConfiguration(),
+    val exclusions: ExclusionsConfiguration = ExclusionsConfiguration(),
 )

--- a/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinLanguageServer.kt
@@ -26,12 +26,12 @@ class KotlinLanguageServer(
     val config: Configuration = Configuration()
 ) : LanguageServer, LanguageClientAware, Closeable {
     val databaseService = DatabaseService()
-    val classPath = CompilerClassPath(config.compiler, config.scripts, config.codegen, databaseService)
+    val classPath = CompilerClassPath(config.compiler, config.scripts, config.exclusions, config.codegen, databaseService)
 
     private val tempDirectory = TemporaryDirectory()
     private val uriContentProvider = URIContentProvider(ClassContentProvider(config.externalSources, classPath, tempDirectory, CompositeSourceArchiveProvider(JdkSourceArchiveProvider(classPath), ClassPathSourceArchiveProvider(classPath))))
     val sourcePath = SourcePath(classPath, uriContentProvider, config.indexing, databaseService)
-    val sourceFiles = SourceFiles(sourcePath, uriContentProvider, config.scripts)
+    val sourceFiles = SourceFiles(sourcePath, uriContentProvider, config.scripts, config.exclusions)
 
     private val textDocuments = KotlinTextDocumentService(sourceFiles, sourcePath, config, tempDirectory, uriContentProvider, classPath)
     private val workspaces = KotlinWorkspaceService(sourceFiles, sourcePath, classPath, textDocuments, config)

--- a/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
+++ b/server/src/main/kotlin/org/javacs/kt/KotlinWorkspaceService.kt
@@ -188,6 +188,13 @@ class KotlinWorkspaceService(
                 get("useKlsScheme")?.asBoolean?.let { externalSources.useKlsScheme = it }
                 get("autoConvertToKotlin")?.asBoolean?.let { externalSources.autoConvertToKotlin = it }
             }
+
+            // Update source file exclusions
+            get("exclusions")?.asJsonObject?.apply {
+                val exclusions = config.exclusions
+                get("excludePatterns")?.asString?.let { exclusions.excludePatterns = it }
+                sf.updateExclusions()
+            }
         }
 
         LOG.info("Updated configuration: {}", settings)

--- a/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
+++ b/server/src/main/kotlin/org/javacs/kt/SourceFiles.kt
@@ -66,10 +66,11 @@ private class NotifySourcePath(private val sp: SourcePath) {
 class SourceFiles(
     private val sp: SourcePath,
     private val contentProvider: URIContentProvider,
-    private val scriptsConfig: ScriptsConfiguration
+    private val scriptsConfig: ScriptsConfiguration,
+    private val exclusionsConfig: ExclusionsConfiguration,
 ) {
     private val workspaceRoots = mutableSetOf<Path>()
-    private var exclusions = SourceExclusions(workspaceRoots, scriptsConfig)
+    private var exclusions = SourceExclusions(workspaceRoots, scriptsConfig, exclusionsConfig)
     private val files = NotifySourcePath(sp)
     private val open = mutableSetOf<URI>()
 
@@ -181,7 +182,7 @@ class SourceFiles(
 
     private fun findSourceFiles(root: Path): Set<URI> {
         val sourceMatcher = FileSystems.getDefault().getPathMatcher("glob:*.{kt,kts}")
-        return SourceExclusions(listOf(root), scriptsConfig)
+        return SourceExclusions(listOf(root), scriptsConfig, exclusionsConfig)
             .walkIncluded()
             .filter { sourceMatcher.matches(it.fileName) }
             .map(Path::toUri)
@@ -189,7 +190,7 @@ class SourceFiles(
     }
 
     fun updateExclusions() {
-        exclusions = SourceExclusions(workspaceRoots, scriptsConfig)
+        exclusions = SourceExclusions(workspaceRoots, scriptsConfig, exclusionsConfig)
         LOG.info("Updated exclusions: ${exclusions.excludedPatterns}")
     }
 

--- a/server/src/test/kotlin/org/javacs/kt/CompiledFileTest.kt
+++ b/server/src/test/kotlin/org/javacs/kt/CompiledFileTest.kt
@@ -36,7 +36,7 @@ class CompiledFileTest {
         val file = testResourcesRoot().resolve("compiledFile/CompiledFileExample.kt")
         val content = Files.readAllLines(file).joinToString("\n")
         val parse = compiler.createKtFile(content, file)
-        val classPath = CompilerClassPath(CompilerConfiguration(), ScriptsConfiguration(), CodegenConfiguration(), DatabaseService())
+        val classPath = CompilerClassPath(CompilerConfiguration(), ScriptsConfiguration(), ExclusionsConfiguration(), CodegenConfiguration(), DatabaseService())
         val sourcePath = listOf(parse)
         val (context, container) = compiler.compileKtFiles(sourcePath, sourcePath)
         CompiledFile(content, parse, context, container, sourcePath, classPath)

--- a/shared/src/main/kotlin/org/javacs/kt/ExclusionsConfiguration.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/ExclusionsConfiguration.kt
@@ -1,0 +1,5 @@
+package org.javacs.kt
+
+data class ExclusionsConfiguration(
+    var excludePatterns: String = "", // Semicolon-separated list of glob patterns
+)

--- a/shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt
+++ b/shared/src/main/kotlin/org/javacs/kt/SourceExclusions.kt
@@ -7,21 +7,21 @@ import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.Paths
 
-// TODO: Read exclusions from gitignore/settings.json/... instead of
-// hardcoding them
 class SourceExclusions(
     private val workspaceRoots: Collection<Path>,
-    private val scriptsConfig: ScriptsConfiguration
+    private val scriptsConfig: ScriptsConfiguration,
+    private val exclusionsConfig: ExclusionsConfiguration,
 ) {
-    val excludedPatterns = (listOf(
+    val configuredExclusions = exclusionsConfig.excludePatterns.split(";").map { it.trim() }.filter { it.isNotEmpty() }
+    val excludedPatterns = listOf(
         ".git", ".hg", ".svn",                                                      // Version control systems
         ".idea", ".idea_modules", ".vs", ".vscode", ".code-workspace", ".settings", // IDEs
-        "bazel-*", "bin", "build", "node_modules", "target",                        // Build systems
+        "bazel-*", "bin", "node_modules",                                           // Build systems
     ) + when {
         !scriptsConfig.enabled -> listOf("*.kts")
         !scriptsConfig.buildScriptsEnabled -> listOf("*.gradle.kts")
         else -> emptyList()
-    })
+    } + configuredExclusions
 
     private val exclusionMatchers = excludedPatterns
         .map { FileSystems.getDefault().getPathMatcher("glob:$it") }


### PR DESCRIPTION
Removes a common nuisance around generated source files (#464, #594, #601) and adds a configuration option to exclude specified patterns when desired.
