### PR TITLE
fix: Publish platform maven artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           tag="${{ steps.tag.outputs.tag }}"
           gh release upload "$tag" server/build/distributions/*
       - name: Deploy Maven artifacts to GitHub Packages
-        run: ./gradlew :shared:publish :server:publish
+        run: ./gradlew :shared:publish :server:publish :platform:publish
         env:
           GPR_USERNAME: ${{ github.actor }}
           GPR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/buildSrc/src/main/kotlin/kotlin-language-server.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-language-server.publishing-conventions.gradle.kts
@@ -1,23 +1,8 @@
 plugins {
-    `maven-publish`
-}
-
-repositories {
-    mavenCentral()
+    id("kotlin-language-server.publishing-repository-conventions")
 }
 
 publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/fwcd/kotlin-language-server")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("GPR_USERNAME")
-                password = project.findProperty("gpr.key") as String? ?: System.getenv("GPR_PASSWORD")
-            }
-        }
-    }
-
     publications {
         register("gpr", MavenPublication::class) {
             from(components["java"])

--- a/buildSrc/src/main/kotlin/kotlin-language-server.publishing-repository-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-language-server.publishing-repository-conventions.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    `maven-publish`
+}
+
+repositories {
+    mavenCentral()
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/fwcd/kotlin-language-server")
+            credentials {
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("GPR_USERNAME")
+                password = project.findProperty("gpr.key") as String? ?: System.getenv("GPR_PASSWORD")
+            }
+        }
+    }
+}

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -1,4 +1,7 @@
-plugins { id("java-platform") }
+plugins {
+    id("java-platform")
+    id("kotlin-language-server.publishing-repository-conventions")
+}
 
 javaPlatform { allowDependencies() }
 
@@ -27,5 +30,13 @@ dependencies {
         api(libs.org.jetbrains.kotlin.kotlin.scripting.jvm.host)
         api(libs.org.openjdk.jmh.generator.annprocess)
         api(libs.org.xerial.sqlite.jdbc)
+    }
+}
+
+publishing {
+    publications {
+        register("gpr", MavenPublication::class) {
+            from(components["javaPlatform"])
+        }
     }
 }


### PR DESCRIPTION
Publish a maven artifact for the java platform gradle module that is used to version dependencies across other modules. Without this being published, users attempting to resolve the `shared` or `server` modules in gradle from the github package registry will receive an error because the "kotlin-language-server:platform" dependency referenced in the shared and server module POM's cannot be found.

Reproduce The Problem
-------------------------

A minimal `build.gradle` in an empty folder can reproduce the problem. Needs credentials populated to access the package registry.

```kotlin
plugins {
    kotlin("jvm") version "2.1.0"
}
repositories {
    maven {
        name = "Github Maven Package Registry for kotlin-langauge-server"
        url = uri("https://maven.pkg.github.com/fwcd/kotlin-language-server")
        credentials {
            username = "YOUR_GITHUB_USER"
            password = "A_PERSONAL_ACCESS_TOKEN_FOR_YOUR_ACCOUNT"
        }
        content {
            includeGroup("kotlin-language-server")
        }
    }
}
dependencies {
    implementation("kotlin-language-server:server:1.3.13")
}
```

Running `gradle dependencyInsight --dependency "kotlin-language-server"` will yield the following problem.

```
% gradle dependencyInsight --dependency "kotlin-language-server"

> Task :dependencyInsight
kotlin-language-server:server:1.3.13 FAILED
   Failures:
      - Could not resolve kotlin-language-server:server:1.3.13.
          - Could not resolve kotlin-language-server:server:1.3.13.
              - Could not parse POM https://maven.pkg.github.com/fwcd/kotlin-language-server/kotlin-language-server/server/1.3.13/server-1.3.13.pom:
                  - Could not find kotlin-language-server:platform:1.3.13.
                    Searched in the following locations:
                      - https://maven.pkg.github.com/fwcd/kotlin-language-server/kotlin-language-server/platform/1.3.13/platform-1.3.13.pom
                  - If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.

kotlin-language-server:server:1.3.13 FAILED
\--- compileClasspath
```

The error message is a little confusing, but you can ignore the "cannot parse POM", the root cause here is "Could not find kotlin-language-server:platform:1.3.13."

With these changes, and pointing to a snapshot in a local maven repository, instead the module can be successfully retrieved:

```
> Task :dependencyInsight
kotlin-language-server:server:0.0.0-SNAPSHOT
  Variant apiElements:
    | Attribute Name                     | Provided     | Requested    |
    |------------------------------------|--------------|--------------|
    | org.gradle.status                  | integration  |              |
    | org.gradle.category                | library      | library      |
    | org.gradle.dependency.bundling     | external     | external     |
    | org.gradle.jvm.environment         | standard-jvm | standard-jvm |
    | org.gradle.jvm.version             | 11           | 23           |
    | org.gradle.libraryelements         | jar          | classes      |
    | org.gradle.usage                   | java-api     | java-api     |
    | org.jetbrains.kotlin.platform.type | jvm          | jvm          |

kotlin-language-server:server:0.0.0-SNAPSHOT
\--- compileClasspath

```

References
------------

- https://docs.gradle.org/current/userguide/java_platform_plugin.html#sec:java_platform_publishing